### PR TITLE
Add PySpark example; clone initialization action repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Google Cloud Dataproc
 
-This repository contains code and documentation for use with
-[Google Cloud Dataproc](https://cloud.google.com/dataproc/).
+This repository contains code, documentation, and
+[initialization actions](https://cloud.google.com/dataproc/docs/concepts/init-actions)
+for use with [Google Cloud Dataproc](https://cloud.google.com/dataproc/).
 
 ## Additional Dataproc Repositories
 
-You can find more Dataproc resources in these github repositories:
+You can find additional Cloud Dataproc resources, which have not yet been merged
+into this location, in these GitHub repositories:
 
-* [Dataproc initialization
-  actions](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions)
 * [Dataproc python
   examples](https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/dataproc)
 

--- a/examples/python/pyspark-jobs/hello-world.py
+++ b/examples/python/pyspark-jobs/hello-world.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python
+#
+#    Copyright 2017 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# This script is a simple "hello world" PySpark application. This script is
+# useful for basic testing and validation.
+#
+
+
+import pyspark
+
+sc = pyspark.SparkContext()
+rdd = sc.parallelize(['Hello,', 'world!'])
+words = sorted(rdd.collect())
+
+print words

--- a/initialization-actions/README.md
+++ b/initialization-actions/README.md
@@ -1,0 +1,57 @@
+# Dataproc Initialization Actions
+
+When creating a [Google Cloud Dataproc](https://cloud.google.com/dataproc/) cluster, you can specify [initialization actions](https://cloud.google.com/dataproc/init-actions) in executables and/or scripts that Cloud Dataproc will run on all nodes in your Cloud Dataproc cluster immediately after the cluster is set up.
+
+## How are initialization actions used?
+Initialization actions are stored in a [Google Cloud Storage](https://cloud.google.com/storage) bucket and can be passed as a paramater to the `gcloud` command or the `clusters.create` API when creating a Dataproc cluster. For example, to specify an initialization action when creating a cluster with the `gcloud` command, you can run:
+
+    gcloud dataproc clusters create CLUSTER-NAME
+    [--initialization-actions [GCS_URI,...]]
+    [--initialization-action-timeout TIMEOUT]
+
+For convenience, a copy of initialization actions in this repository are stored in the following Cloud Storage bucket which is publicly-accessible:
+
+    gs://dataproc-initialization-actions
+
+The folder structure of this Cloud Storage bucket mirrors this repository. You should be able to use this Cloud Storage bucket (and the initialization scripts within it) for your clusters.
+
+## Why these samples are provided
+These samples are provided to show how various packages and components can be installed on Cloud Dataproc clusters. You should understand how these samples work before running them on your clusters. The initialization actions provided in this repository are provided **without support** and you **use them at your own risk**.
+
+## Actions provided
+This repository presently offers the following actions for use with Cloud Dataproc clusters.
+
+* Install packages/software on the cluster
+  * [Apache Drill](http://drill.apache.org)
+  * [Apache Flink](http://flink.apache.org)
+  * [Apache Kafka](http://kafka.apache.org)
+  * [Apache Oozie](http://oozie.apache.org)
+  * [Apache Tez](http://tez.apache.org)
+  * [Apache Zeppelin](http://zeppelin.apache.org)
+  * [Apache ZooKeeper](http://zookeeper.apache.org)
+  * [Google Cloud Datalab](https://cloud.google.com/datalab/)
+  * [Hive HCatalog](https://cwiki.apache.org/confluence/display/Hive/HCatalog)
+  * [Hue](http://gethue.com)
+  * [IPython](http://ipython.org)
+  * [Presto](http://prestodb.io)
+  * [Anaconda](https://www.continuum.io/why-anaconda)
+* Configure the cluster
+  * Configure a *nice* shell environment
+  * Share a NFS consistency cache
+  * Share a [Google Cloud SQL](https://cloud.google.com/sql/) Hive Metastore
+  * Setup [Google Stackdriver](https://cloud.google.com/stackdriver/) monitoring for a cluster
+
+## For more information
+For more information, review the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions). You can also pose questions to the [Stack Overflow](http://www.stackoverflow.com) comminity with the tag `google-cloud-dataproc`.
+See our other [Google Cloud Platform github
+repos](https://github.com/GoogleCloudPlatform) for sample applications and
+scaffolding for other frameworks and use cases.
+
+
+## Contributing changes
+
+* See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+## Licensing
+
+* See [LICENSE](LICENSE)

--- a/initialization-actions/cloud-sql-proxy/README.MD
+++ b/initialization-actions/cloud-sql-proxy/README.MD
@@ -1,0 +1,49 @@
+# Cloud SQL I/O and Hive Metastore
+
+This initialization action installs a [Google Cloud SQL proxy](https://cloud.google.com/sql/docs/sql-proxy) on every node in a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. It also configures the cluster to store [Apache Hive](https://hive.apache.org) metadata on a given Cloud SQL instance.
+
+## Using this initialization action
+You can use this initialization action to create a Dataproc cluster using a shared hive metastore.:
+
+1. Using the `gcloud` command to create a new 2nd generation Cloud SQL intance (or use a previously created instance)
+
+    ```bash
+    gcloud sql instances create <INSTANCE_NAME> \
+        --tier db-n1-standard-1 \
+        --activation-policy=ALWAYS
+    ```
+  a. Optionally create (or already have) other 2nd generation instances, which you wish to be accessible.
+2. Uploading a copy of this initialization action (`cloud-sql-proxy.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+3. Using the `gcloud` command to create a new cluster with this initialization action.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --scopes sql-admin \
+    --initialization-actions gs://<GCS_BUCKET>/cloud-sql-proxy.sh \
+    --properties hive:hive.metastore.warehouse.dir=gs://<GCS_BUCKET>/hive-warehouse \
+    --metadata "hive-metastore-instance=<PROJECT_ID>:<REGION>:<INSTANCE_NAME>"
+    ```
+  a. Optionally add other instances, paired with distict TCP ports for further I/O.
+
+    ```bash
+    --metadata "additional-cloud-sql-instances=<PROJECT_ID>:<REGION>:<ANOTHER_INSTANCE_NAME>=tcp<PORT_#>[,...]"
+    ```
+4. Submit pyspark_metastore_test.py to the cluster to validate the metatstore and SQL proxies.
+    ```bash
+    gcloud dataproc jobs submit pyspark --cluster <CLUSTER_NAME> pyspark_metastore_test.py
+    ```
+    a. You can test connections to your other instance(s) using the url `"jdbc:mysql//localhost:<PORT_#>?user=root"`
+5. Create another dataproc cluster with the same Cloud SQL metastore.
+    ```bash
+    gcloud dataproc clusters create <ANOTHER_CLUSTER_NAME> \
+    --scopes sql-admin \
+    --initialization-actions gs://<GCS_BUCKET>/cloud-sql-proxy.sh \
+    --metadata "hive-metastore-instance=<PROJECT_ID>:<REGION>:<INSTANCE_NAME>"
+    ```
+6. The two clusters should now be sharing Hive Tables and Spark SQL Dataframes saved as tables.
+
+## Important notes
+* Hive stores the metadata of all tables in it's metastore. It stores the contents of (non-external) tables in a HCFS directory, which is by default on HDFS. If you want to perist your tables beyond the life of the cluster, set "hive.metastore.warehouse.dir" to a shared locations (such as the Cloud Storage directory in the example above). This directory get's baked into the Cloud SQL metastore, so it is recommended to set even if you intend to mostly use external tables. If you place this direcotry in Cloud Storage. You may want to use the shared NFS consistency cache as well.
+* This initalization action can be reconfigured to only install a proxy on the master, if you only wish to have a shared metastore. Set `ENABLE_PROXY_ON_WORKERS` to 0.
+* It can be also be reconfigured to istall proxies without changing the Hive metasore, if you only wish to have the proxies. Set `ENABLE_CLOUD_SQL_METASTORE` to 0 and do not set the `hive-metastore-instance` metadata key.
+* The initialization action creates a `hive` user and `hive_metastore` database in the SQL instance if they don't already exist. It does this by logging in as root with an empty password. You can reconfigure all of this in the script.

--- a/initialization-actions/cloud-sql-proxy/cloud-sql-proxy.sh
+++ b/initialization-actions/cloud-sql-proxy/cloud-sql-proxy.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Copyright 2016 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This init script installs a cloud-sql-proxy on each node in the cluster, and
+# uses that proxy to expose TCP proxies of one or more CloudSQL instances.
+# One of these instances is used for the clusters Hive Metastore.
+set -x -e
+
+ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+METASTORE_INSTANCE="$(/usr/share/google/get_metadata_value attributes/hive-metastore-instance || true)"
+#METASTORE_INSTANCE="$(/usr/share/google/get_metadata_value attributes/hive-warehouse-uri || true)"
+ADDITIONAL_INSTANCES_KEY='attributes/additional-cloud-sql-instances'
+ADDITIONAL_INSTANCES="$(/usr/share/google/get_metadata_value ${ADDITIONAL_INSTANCES_KEY} || true)"
+METASTORE_DB="$(/usr/share/google/get_metadata_value attributes/hive-metastore-db || true)"
+
+# Defaults
+
+# Whether to configure the Hive metastore to point to a Cloud SQL database.
+# This is not required for Hive & Spark I/O.
+ENABLE_CLOUD_SQL_METASTORE=1 # 0 -> false
+
+# Whether to enable the proxy on workers. This is not necessary for the
+# Metastore, but is required for Hive & Spark I/O.
+ENABLE_PROXY_ON_WORKERS=1 # 0 -> false
+
+# Name of CloudSQL instance to use for the metastore. Must already exist.
+# Uncomment to hard code an instance. Metadata will still take precedence.
+METASTORE_INSTANCE_DEFAULT= # my-project:my-region:my-instance
+METASTORE_INSTANCE="${METASTORE_INSTANCE:-${METASTORE_INSTANCE_DEFAULT}}"
+
+# Name of MySQL database to use for the metastore. Will be created if it doesn't
+# exist.
+METASTORE_DB="${METASTORE_DB:-hive_metastore}"
+
+# MySQL user to use to access metastore.
+HIVE_USER='hive'
+
+# MySQL password to use to access metastore.
+HIVE_USER_PASSWORD='hive-password'
+
+# MySQL root password used to initialize metastore.
+# Empty is the default for new CloudSQL instances.
+MYSQL_ROOT_PASSWORD=''
+
+PROXY_DIR='/var/run/cloud_sql_proxy'
+PROXY_BIN='/usr/local/bin/cloud_sql_proxy'
+INIT_SCRIPT="/usr/lib/systemd/system/cloud-sql-proxy.service"
+METASTORE_PROXY_PORT=3306
+
+# Validation
+if (( ! ENABLE_CLOUD_SQL_METASTORE )) && [[ -z "${ADDITIONAL_INSTANCES}" ]];
+then
+  echo 'No Cloud SQL instances to proxy' >&2
+  exit 1
+fi
+
+PROXY_INSTANCES_FLAGS=''
+if (( ENABLE_CLOUD_SQL_METASTORE )); then
+  if [[ -z "${METASTORE_INSTANCE}" ]]; then
+    echo 'Must specify hive-metastore-instance VM metadata' >&2
+    exit 1
+  elif ! [[ "${METASTORE_INSTANCE}" =~ .+:.+:.+ ]]; then
+    echo 'hive-metastore-instance must be of form project:region:instance' >&2
+    exit 1
+  elif ! [[ "${METASTORE_INSTANCE}" =~ =tcp:[0-9]+$ ]]; then
+    METASTORE_INSTANCE+="=tcp:${METASTORE_PROXY_PORT}"
+  else
+    METASTORE_PROXY_PORT="${METASTORE_INSTANCE##*:}"
+  fi
+  PROXY_INSTANCES_FLAGS+=" --instances ${METASTORE_INSTANCE}"
+fi
+
+if [[ -n "${ADDITIONAL_INSTANCES}" ]]; then
+  # Pass additional instances straight to the proxy.
+  PROXY_INSTANCES_FLAGS+=" --instances_metadata=${ADDITIONAL_INSTANCES_KEY}"
+fi
+
+# Disable Hive Metastore and MySql Server
+if [[ "${ROLE}" == 'Master' ]] && (( ENABLE_CLOUD_SQL_METASTORE )); then
+  systemctl stop hive-metastore
+  systemctl stop mysql
+  systemctl disable mysql
+fi
+
+if [[ "${ROLE}" == 'Master' ]] || (( ENABLE_PROXY_ON_WORKERS )); then
+  # Install proxy.
+  wget -q https://dl.google.com/cloudsql/cloud_sql_proxy.linux.amd64
+  mv cloud_sql_proxy.linux.amd64 ${PROXY_BIN}
+  chmod +x ${PROXY_BIN}
+
+  mkdir -p ${PROXY_DIR}
+
+  # Install proxy as systemd service for reboot tolerance.
+  cat << EOF > ${INIT_SCRIPT}
+[Unit]
+Description=Google Cloud SQL Proxy
+After=local-fs.target network-online.target
+After=google.service
+Before=shutdown.target
+
+[Service]
+Type=simple
+ExecStart=${PROXY_BIN} \
+  -dir ${PROXY_DIR} \
+  ${PROXY_INSTANCES_FLAGS}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+  chmod a+rw ${INIT_SCRIPT}
+  systemctl enable cloud-sql-proxy
+  systemctl start cloud-sql-proxy
+
+  echo 'Cloud SQL Proxy installation succeeded' >&2
+
+  if (( ENABLE_CLOUD_SQL_METASTORE )); then
+    # Update hive-site.xml
+    cat << EOF > hive-template.xml
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+  <property>
+    <name>javax.jdo.option.ConnectionURL</name>
+    <value>jdbc:mysql://localhost:${METASTORE_PROXY_PORT}/${METASTORE_DB}</value>
+    <description>the URL of the MySQL database</description>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionUserName</name>
+    <value>${HIVE_USER}</value>
+  </property>
+  <property>
+    <name>javax.jdo.option.ConnectionPassword</name>
+    <value>${HIVE_USER_PASSWORD}</value>
+  </property>
+</configuration>
+EOF
+
+    bdconfig merge_configurations \
+        --configuration_file /etc/hive/conf/hive-site.xml \
+        --source_configuration_file hive-template.xml \
+        --clobber
+  fi
+fi
+
+if [[ "${ROLE}" == 'Master' ]] && (( ENABLE_CLOUD_SQL_METASTORE )); then
+  # Configure mysql client to talk to metastore as root.
+  cat << EOF > /etc/mysql/conf.d/cloud-sql-proxy.cnf
+[client]
+protocol = tcp
+port = ${METASTORE_PROXY_PORT}
+user = root
+password = ${MYSQL_ROOT_PASSWORD}
+EOF
+
+  # Check if metastore is initialized.
+  if ! mysql -u "${HIVE_USER}" -p"${HIVE_USER_PASSWORD}" -e ''; then
+      mysql -e \
+        "CREATE USER '${HIVE_USER}' IDENTIFIED BY '${HIVE_USER_PASSWORD}';"
+  fi
+  if mysql -e "use ${METASTORE_DB}"; then
+    # Extract the warehouse URI.
+    HIVE_WAREHOURSE_URI=$(mysql -Nse \
+      "SELECT DB_LOCATION_URI FROM ${METASTORE_DB}.DBS WHERE NAME = 'default';")
+    bdconfig set_property \
+        --name 'hive.metastore.warehouse.dir' \
+        --value "${HIVE_WAREHOURSE_URI}" \
+        --configuration_file /etc/hive/conf/hive-site.xml \
+        --clobber
+  else
+    # Initialize database with current warehouse URI
+    mysql -e \
+      "CREATE DATABASE ${METASTORE_DB}; \
+      GRANT ALL PRIVILEGES ON ${METASTORE_DB}.* TO '${HIVE_USER}';"
+    /usr/lib/hive/bin/schematool -dbType mysql -initSchema
+  fi
+
+  # Start metastore back up.
+  systemctl start hive-metastore
+
+  # Validate it's functioning.
+  if ! hive -e 'SHOW TABLES;' >& /dev/null; then
+    echo 'Failed to bring up Cloud SQL Metastore' >&2
+    exit 1
+  fi
+  echo 'Cloud SQL Hive Metastore initialization succeeded' >&2
+fi

--- a/initialization-actions/cloud-sql-proxy/pyspark_metastore_test.py
+++ b/initialization-actions/cloud-sql-proxy/pyspark_metastore_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/python
+
+import pyspark
+import random
+import string
+
+# Constants that must match the constants in cloud-sql-proxy.sh
+METASTORE_DB='hive_metastore'
+HIVE_USER='hive'
+HIVE_USER_PASSWORD='hive-password'
+
+sc = pyspark.SparkContext()
+sqlContext = pyspark.sql.HiveContext(sc)
+
+# Find available table name.
+table_names = sqlContext.tableNames()
+test_table_name = None
+while not test_table_name or test_table_name in table_names:
+  test_table_name = 'table_' + ''.join(
+      [random.choice(string.ascii_lowercase) for x in range(4)])
+
+# Create table.
+sqlContext.range(10).write.saveAsTable(test_table_name)
+
+# Read table metadata from Cloud SQL proxy.
+tables = sqlContext.read.jdbc(
+    'jdbc:mysql:///{}?user={}&password={}'.format(
+        METASTORE_DB, HIVE_USER, HIVE_USER_PASSWORD),
+    'TBLS')
+test_table = tables.where(TBL_NAME == test_table_name).collect()[0]
+
+print 'Successfully found table {} in Cloud SQL Hive metastore'.format(
+    test_table.TBL_NAME)
+
+# Clean up table.
+sqlContext.sql('DROP TABLE ' + test_table_name)

--- a/initialization-actions/conda/README.MD
+++ b/initialization-actions/conda/README.MD
@@ -1,0 +1,119 @@
+# Miniconda (a Python distro, along with package and environment manager, from Continuum Analytics)
+
+## Overview
+
+This folder contains initialization actions for use Miniconda / conda, who can be introduced as:
+ 
+- [Minconda](http://conda.pydata.org/miniconda.html), a barebones version of [Anaconda](https://www.continuum.io/why-anaconda) of an open source (and totally legit) Python distro from Continuum Analytics, alongside,
+- [conda](http://conda.pydata.org/docs/), an open source (and amazing) package and environment management system.
+
+This allows Dataproc users to quickly and easily provision a Dataproc cluster leveraging conda's powerful management capabilities, by specifying a list of conda and / or pip packages along with use of [conda environment definitions](https://github.com/conda/conda-env#environment-file-example). All configuration is exposed via environment variables set to sane point-and-shoot defaults.
+
+An example, to be used in a bash shell script:
+
+```
+gcloud dataproc clusters create my-dataproc-cluster \
+    --initialization-actions \
+        gs://dataproc-initialization-actions/jupyter/create-my-cluster.sh \
+    --bucket my-dataproc-bucket \
+    --num-workers 2 \
+    --worker-machine-type=n1-standard-4 \
+    --master-machine-type=n1-standard-4
+```
+
+Where `create-my-cluster.sh` specifies a list of conda and / or pip packages to install:
+
+```
+# Install Miniconda / conda
+./dataproc-initialization-actions/conda/bootstrap-conda.sh
+# Update conda root environment with specific packages in pip and conda
+CONDA_PACKAGES='pandas dash scikit-learn'
+PIP_PACKAGES='plotly cufflinks'
+CONDA_PACKAGES=$CONDA_PACKAGES PIP_PACKAGES=$PIP_PACKAGES ./dataproc-initialization-actions/conda/install-conda-env.sh
+```
+
+Similarly, one can also specify a [conda environment yml file](https://github.com/conda/conda-env):
+
+```
+#!/usr/bin/env bash
+
+CONDA_ENV_YAML_GSC_LOC="gs://my-bucket/path/to/conda-environment.yml"
+CONDA_ENV_YAML_PATH="/root/conda-environment.yml"
+echo "Downloading conda environment at $CONDA_ENV_YAML_GSC_LOC to $CONDA_ENV_YAML_PATH ... "
+gsutil -m cp -r $CORAL_ENV_YAML_GSC_LOC $CONDA_ENV_YAML_PATH
+
+# Install Miniconda / conda
+./dataproc-initialization-actions/conda/bootstrap-conda.sh
+# Create / Update conda environment via conda yaml
+CONDA_ENV_YAML=$CONDA_ENV_YAML_PATH ./dataproc-initialization-actions/conda/install-conda-env.sh
+
+```
+
+
+## Details 
+
+### bootstrap-conda.sh
+
+`bootstrap-conda.sh` contains logic for quickly configuring and installing Miniconda across the dataproc cluster. Defaults to [`Miniconda3-latest-Linux-x86_64.sh`](https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh) package (e.g., Python 3), however, users can easily config for targeted versions via the following env vars (see script source for all options):
+    - `MINICONDA_VARIANT`: the Python version can be `2` or `3`
+    - `MINICONDA_VER`: the Miniconda version (e.g., `4.0.5`)
+In addition, the script:
+- downloads and installs Miniconda to the `$HOME` directory
+- updates `$PATH`, exposing conda across all shell processes (for both interactive and batch sessions)
+- installs some useful extensions:
+    - [`conda-build`](https://github.com/conda/conda-build)
+    - [`anaconda-client`](https://github.com/Anaconda-Server/anaconda-client)
+    
+See the script source for more options on configuration. :)
+
+### install-conda-env.sh
+
+`install-conda-env.sh` contains logic for creating a conda environment and installing conda and/or pip packages. Defaults include:
+
+- if no conda environment name is specified, uses `root` (recommended).
+- detects if conda environment has already been created.
+- updates `/etc/profile` to activate the created environment at login (if needed)
+
+Note: When creating a conda environment using an environment.yml (via setting .yml path in `CONDA_ENV_YAML`), the `install-conda-env.sh` script simply *updates the **root** environment* with dependencies specified in the file (i.e., ignoring the `name:` key). This sidesteps some conda issues in `source activate`ing, while still providing all dependencies across the Dataproc cluster.
+
+If nothing else you need to include the bootstrap file as well eg.: 
+gcloud dataproc clusters create foo --initialization-actions gs://dataproc-initialization-actions/conda/bootstrap-conda.sh,gs://dataproc-initialization-actions/conda/install-conda-env.sh
+
+
+### Notes on running Python 3
+
+Starting with Python 3.3, hash randomization is enabled by default (see docs for [object.\__hash__](https://docs.python.org/3/reference/datamodel.html#object.__hash__)). Spark attempts to correct this by setting the `PYTHONHASHSEED` environment variable, but a [small bug in Spark](https://issues.apache.org/jira/browse/SPARK-13330) keeps the env var from propogating to all executors.
+
+The `boostrap-conda.sh` initialization action fixes this issue; users will not have to take any additional actions to use Python 3 on Dataproc. Alternatively, users can pass the following `properties` argument when creating a DataProc cluster:
+```
+gcloud dataproc clusters create --properties spark:spark.executorEnv.PYTHONHASHSEED=0 ...
+```
+Note that at this time Dataproc will *NOT* accept the property value when submitting a job; it must be passed when the cluster is created.
+
+
+## Testing Installation
+
+A quick test to ensure a correct installation of conda, we can submit jobs that collect distinct paths to the Python distribution across all Spark executors. For both local (e.g., running from dataproc cluster master node) and remote (e.g. submitting a job via the dataproc API) jobs, the result should be a list with a single path: `['/usr/local/bin/miniconda/bin/python']`. For example
+
+
+### Local Job Test
+
+After sshing to master node (e.g., `gcloud compute ssh $DATAPROC_CLUSTER_NAME-m`), run the `get-sys-exec.py` script contained in this directory:
+
+```bash
+> spark-submit get-sys-exec.py
+... # Lots of output
+['/usr/local/bin/miniconda/bin/python']
+...
+```
+
+### Remote Job Test
+
+From command line of local / host machine, one can submit remote job:
+
+```bash
+> gcloud dataproc jobs submit pyspark --cluster $DATAPROC_CLUSTER_NAME get-sys-exec.py
+... # Lots of output
+['/usr/local/bin/miniconda/bin/python']
+...
+```

--- a/initialization-actions/conda/bootstrap-conda.sh
+++ b/initialization-actions/conda/bootstrap-conda.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+set -e
+# Modified from bootstrap-conda.sh script, see:
+# https://gist.github.com/nehalecky/aea2100ca8bad83fe974
+
+# Run on BOTH 'Master' and 'Worker' nodes
+#ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+#if [[ "${ROLE}" == 'Master' ]]; then
+MINICONDA_VARIANT=$(/usr/share/google/get_metadata_value attributes/MINICONDA_VARIANT || true)
+
+if [[ ! -v CONDA_INSTALL_PATH ]]; then
+    echo "CONDA_INSTALL_PATH not set, setting ..."
+    CONDA_INSTALL_PATH="/usr/local/bin/miniconda"
+    echo "Set CONDA_INSTALL_PATH to $CONDA_INSTALL_PATH"
+fi
+# 0. Specify Miniconda version
+## 0.1 A few parameters
+## specify base operating system
+if [[ ! -v OS_TYPE ]]; then
+    echo "OS_TYPE not set, setting  ..."
+    OS_TYPE="Linux-x86_64.sh"
+    echo "Set OS_TYPE to $OS_TYPE"
+fi
+## Python 2 or 3?
+if [[ ! -v MINICONDA_VARIANT ]]; then
+    echo "MINICONDA_VARIANT not set, setting ... "
+    MINICONDA_VARIANT="Miniconda3"  #for Python 3.5.x
+    echo "Set MINICONDA_VARIANT to $MINICONDA_VARIANT"
+else
+    MINICONDA_VARIANT="Miniconda$MINICONDA_VARIANT"
+fi
+
+## specify Miniconda release (e.g., MINICONDA_VER='4.0.5')
+if [[ ! -v MINICONDA_VER ]]; then
+    echo "MINICONDA_VER not set, setting ..."
+    MINICONDA_VER='latest'
+    set "Set MINICONDA_VER to $MINICONDA_VER"
+fi
+
+## 0.2 Compute Miniconda version
+miniconda="$MINICONDA_VARIANT-$MINICONDA_VER-$OS_TYPE"
+echo "Miniconda version specified: $miniconda"
+## 0.3 Set MD5 hash for check (if desired)
+#expectedHash="b1b15a3436bb7de1da3ccc6e08c7a5df"
+
+# 1. Setup Miniconda Install
+## 1.1 Define Miniconda install directory
+echo "Working directory: $PWD"
+if [[ ! -v $PROJ_DIR ]]; then
+    echo "No path argument specified, setting install directory as working directory: $PWD."
+    PROJ_DIR=$PWD
+fi
+
+## 1.2 Setup Miniconda
+cd $PROJ_DIR
+MINICONDA_SCRIPT_PATH="$PROJ_DIR/$miniconda"
+echo "Defined miniconda script path: $MINICONDA_SCRIPT_PATH"
+
+if [[ -f "$MINICONDA_SCRIPT_PATH" ]]; then
+  echo "Found existing Miniconda script at: $MINICONDA_SCRIPT_PATH"
+else
+  echo "Downloading Miniconda script to: $MINICONDA_SCRIPT_PATH ..."
+  wget http://repo.continuum.io/miniconda/$miniconda -P "$PROJ_DIR"
+  echo "Downloaded $miniconda!"
+  ls -al $MINICONDA_SCRIPT_PATH
+  chmod 755 $MINICONDA_SCRIPT_PATH
+fi
+
+## 1.3 #md5sum hash check of miniconda installer
+if [[ -v expectedHash ]]; then
+    md5Output=$(md5sum $MINICONDA_SCRIPT_PATH | awk '{print $1}')
+    if [ "$expectedHash" != "$md5Output" ]; then
+        echo "Unexpected md5sum $md5Output for $miniconda"
+        exit 1
+    fi
+fi
+
+# 2. Install conda
+## 2.1 Via bootstrap
+LOCAL_CONDA_PATH="$PROJ_DIR/miniconda"
+if [[ ! -d $LOCAL_CONDA_PATH ]]; then
+    #blow away old symlink / default Miniconda install
+    rm -rf "$PROJ_DIR/miniconda"
+    # Install Miniconda
+    echo "Installing $miniconda to $CONDA_INSTALL_PATH..."
+    bash $MINICONDA_SCRIPT_PATH -b -p $CONDA_INSTALL_PATH -f
+    chmod 755 $CONDA_INSTALL_PATH
+    #create symlink
+    ln -sf $CONDA_INSTALL_PATH "$PROJ_DIR/miniconda"
+    chmod 755 "$PROJ_DIR/miniconda"
+else
+    echo "Existing directory at path: $LOCAL_CONDA_PATH, skipping install!"
+fi
+
+## 2.2 Update PATH and conda...
+echo "Setting environment variables..."
+CONDA_BIN_PATH="$CONDA_INSTALL_PATH/bin"
+export PATH="$CONDA_BIN_PATH:$PATH"
+echo "Updated PATH: $PATH"
+echo "And also HOME: $HOME"
+hash -r
+which conda
+conda config --set always_yes true --set changeps1 false
+
+echo "Updating conda..."
+conda update -q conda
+# Useful for debugging any issues with conda
+conda info -a
+
+# Install useful conda utilities in root env
+echo "Installing useful conda utilities in root env..."
+conda install anaconda-client conda-build
+
+conda update --all
+
+# 2.3 Update global profiles to add the miniconda location to PATH and PYTHONHASHSEED
+# based on: http://stackoverflow.com/questions/14637979/how-to-permanently-set-path-on-linux
+# and also: http://askubuntu.com/questions/391515/changing-etc-environment-did-not-affect-my-environemtn-variables
+# and this: http://askubuntu.com/questions/128413/setting-the-path-so-it-applies-to-all-users-including-root-sudo
+echo "Updating global profiles to export miniconda bin location to PATH and set PYTHONHASHSEED ..."
+#if grep -ir "CONDA_BIN_PATH=$CONDA_BIN_PATH" /root/.bashrc  #/$HOME/.bashrc
+if [[ -f "/etc/profile.d/conda_config.sh" ]]
+    then
+    echo "conda_config.sh found in /etc/profile.d/, skipping..."
+else
+    echo "Adding path definition to profiles..."
+    echo "export CONDA_BIN_PATH=$CONDA_BIN_PATH" | tee -a /etc/profile.d/conda_config.sh  /etc/*bashrc /etc/profile
+    echo 'export PATH=$CONDA_BIN_PATH:$PATH' | tee -a /etc/profile.d/conda_config.sh  /etc/*bashrc /etc/profile
+    # Fix issue with Python3 hash seed.
+    # Issue here: https://issues.apache.org/jira/browse/SPARK-12100
+    # Fix here: http://blog.stuart.axelbrooke.com/python-3-on-spark-return-of-the-pythonhashseed/
+    echo "Adding PYTHONHASHSEED=0 to profiles and spark-defaults.conf..."
+    echo "export PYTHONHASHSEED=0" | tee -a  /etc/profile.d/conda_config.sh  /etc/*bashrc  /usr/lib/spark/conf/spark-env.sh
+    echo "spark.executorEnv.PYTHONHASHSEED=0" >> /etc/spark/conf/spark-defaults.conf
+fi
+
+## 3. Ensure that Anaconda Python and PySpark play nice
+### http://blog.cloudera.com/blog/2015/09/how-to-prepare-your-apache-hadoop-cluster-for-pyspark-jobs/
+echo "Ensure that Anaconda Python and PySpark play nice by all pointing to same Python distro..."
+if [[ ! -v PYSPARK_PYTHON ]]; then  echo "export PYSPARK_PYTHON=$CONDA_BIN_PATH/python" | tee -a  /etc/profile.d/conda_config.sh  /etc/*bashrc /etc/environment /usr/lib/spark/conf/spark-env.sh; fi
+
+echo "Finished bootstrapping via Miniconda, sourcing /etc/profile ..."
+source /etc/profile

--- a/initialization-actions/conda/get-sys-exec.py
+++ b/initialization-actions/conda/get-sys-exec.py
@@ -1,0 +1,18 @@
+import pyspark
+import sys
+import os
+
+pyhashseed = os.environ['PYTHONHASHSEED']
+print(pyhashseed)
+print(type(pyhashseed))
+print(sys.version)
+
+
+if sys.version >= '3.3' and 'PYTHONHASHSEED' not in os.environ:
+    raise Exception("Randomness of hash of string should be disabled via PYTHONHASHSEED")
+
+else:
+   sc = pyspark.SparkContext()
+   distData = sc.parallelize(range(100))
+   python_distros = distData.map(lambda x: sys.executable).distinct().collect()
+   print(python_distros)

--- a/initialization-actions/conda/install-conda-env.sh
+++ b/initialization-actions/conda/install-conda-env.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+set -e
+
+# 0.1 Ensure we have conda installed and available on the PATH
+if [[ ! -v CONDA_BIN_PATH ]]; then
+    source /etc/profile.d/conda_config.sh
+fi
+
+echo "echo \$USER: $USER"
+echo "echo \$PWD: $PWD"
+echo "echo \$PATH: $PATH"
+echo "echo \$CONDA_BIN_PATH: $CONDA_BIN_PATH"
+
+# 0.2. Specify conda environment name (recommend leaving as root)
+if [[ ! -v CONDA_ENV_NAME ]]; then
+    echo "No conda environment name specified, setting to 'root' env..."
+    CONDA_ENV_NAME='root'
+# Force conda env name to be set to root for now, until a braver soul manages the complexity of environment activation
+# across the cluster.
+else
+    echo "conda environment name is set to $CONDA_ENV_NAME"
+    if [[ ! $CONDA_ENV_NAME == 'root' ]]
+        then
+        echo "Custom conda environment names not supported at this time."
+        echo "Force setting conda env to 'root'..."
+    fi
+    CONDA_ENV_NAME='root'
+fi
+
+conda update --all
+# 1. Create conda environment
+# 1.1 Update conda env from conda environment.yml (if specified)
+# For Dataproc provisioning, we should install to root conda env.
+if [[ -v CONDA_ENV_YAML ]]; then
+    #CONDA_ENV_NAME=$(grep 'name: ' $CONDA_ENV_YAML | awk '{print $2}')
+    # if conda environment name is root, we *update* the root environment with env yaml
+    if [[ $CONDA_ENV_NAME == 'root' ]]
+        then
+        echo "Updating root environment with file $CONDA_ENV_YAML"
+        conda env update --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML
+        echo "Root environment updated..."
+    # otherwise, perform a typical environment creation via install
+    else
+        echo "Creating $CONDA_ENV_NAME environment with file $CONDA_ENV_YAML"
+        conda env create --name=$CONDA_ENV_NAME --file=$CONDA_ENV_YAML
+        echo "conda environment $CONDA_ENV_NAME created..."
+    fi
+fi
+
+# 1. Or create conda env manually.
+echo "Attempting to create conda environment: $CONDA_ENV_NAME"
+if conda info --envs | grep -q $CONDA_ENV_NAME
+    then
+    echo "conda environment $CONDA_ENV_NAME detected, skipping env creation..."
+else
+    echo "Creating conda environment directly..."
+    conda create --quiet --yes --name=$CONDA_ENV_NAME python || true
+    echo "conda environment $CONDA_ENV_NAME created..."
+fi
+if [[ ! $CONDA_ENV_NAME == 'root' ]]
+    then
+    echo "Activating $CONDA_ENV_NAME environment..."
+    source activate $CONDA_ENV_NAME
+fi
+
+# 3. Install conda and pip packages (if specified)
+if [[ -v CONDA_PACKAGES ]]; then
+    echo "Installing conda packages for $CONDA_ENV_NAME..."
+    echo "conda packages requested: $CONDA_PACKAGES"
+    conda install $CONDA_PACKAGES
+fi
+if [[ -v PIP_PACKAGES ]]; then
+    echo "Installing pip packages for $CONDA_ENV_NAME..."
+    echo "conda packages requested: $PIP_PACKAGES"
+    pip install $PIP_PACKAGES
+fi
+
+# 2. Append profiles with conda env source activate
+echo "Attempting to append /etc/profile.d/conda_config.sh to activate conda env at login..."
+if [[ -f "/etc/profile.d/conda_config.sh"  ]]  && [[ ! $CONDA_ENV_NAME == 'root' ]]
+    then
+    if grep -ir "source activate $CONDA_ENV_NAME" /etc/profile.d/conda_config.sh
+        then
+        echo "conda env activation found in /etc/profile.d/conda_config.sh, skipping..."
+    else
+        echo "Appending /etc/profile.d/conda_config.sh to activate conda env $CONDA_ENV_NAME for shell..."
+        sudo echo "source activate $CONDA_ENV_NAME" | tee -a /etc/profile.d/conda_config.sh
+        echo "./etc/profile.d/conda_config.sh successfully appended!"
+    fi
+elif [[ $CONDA_ENV_NAME == 'root' ]]
+    then
+    echo "The conda env specified is 'root', the default environment, no need to activate, skipping..."
+else
+    echo "No file detected at /etc/profile.d/conda_config.sh..."
+    echo "Are you sure you installed conda via bootstrap-conda.sh?"
+    exit 1
+fi

--- a/initialization-actions/datalab/README.md
+++ b/initialization-actions/datalab/README.md
@@ -1,0 +1,28 @@
+# Datalab Initialization Action
+
+This initialization action downloads and runs a [Google Cloud Datalab](https://cloud.google.com/datalab/) Docker container on a Dataproc cluster. You will need to connect to Datalab using an SSH tunnel.
+
+Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with the Datalab server installed by:
+
+1. Uploading a copy of the initialization action (`datalab.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://<GCS_BUCKET>/datalab/datalab.sh \
+        --scopes cloud-platform
+    ```
+1. Once the cluster has been created, Datalab is configured to run on port `8080` on the master node in a Dataproc cluster. To connect to the Datalab web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.
+1. Once you bring up a notebook, you should have the normal PySpark environment configured with `sc`, `sqlContext`, and `spark` predefined.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Notes
+
+* PySpark's [`DataFrame.toPandas()`](http://spark.apache.org/docs/latest/api/python/pyspark.sql.html#pyspark.sql.DataFrame.toPandas) method is useful for integrating with Datalab APIs.
+  * Remember that Panda's DataFrames must fit on the master, whereas Spark's can fill a cluster.
+  * Datalab has a number of notebooks documenting its [Pandas](http://pandas.pydata.org/)' integrations.
+* This script requires that Datalab run on port `:8080`. If you normally run another server on that port (e.g. Zeppelin), consider moving it. Note running multiple Spark sessions can consume a lot of cluster resources and can cause problems on moderately small clusters.
+* Datalab requires the `cloud-platform` scope even to access Google Cloud Storage and BigQuery.
+* If you [build your own Datalab images](https://github.com/googledatalab/datalab/wiki/Development-Environment), you can specify `--metadata=docker-image=gcr.io/<PROJECT>/<IMAGE>` to point to your image.
+* If you normally only run Datalab kernels on VMs and connect to them with a local Docker frontend, set the flag `--metadata=docker-image=gcr.io/cloud-datalab/datalab-gateway` and then set `GATEWAY_VM` to your cluster's master node in your local `docker`command [as described here](https://cloud.google.com/datalab/docs/quickstarts/quickstart-gce#install_the_datalab_docker_container_on_your_computer).

--- a/initialization-actions/datalab/datalab.sh
+++ b/initialization-actions/datalab/datalab.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2016 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This init script installs Google Cloud Datalab on the master node of a
+# Dataproc cluster.
+
+set -e -x
+
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+PROJECT=$(/usr/share/google/get_metadata_value ../project/project-id)
+DOCKER_IMAGE=$(/usr/share/google/get_metadata_value attributes/docker-image || true)
+
+if [[ "${ROLE}" == 'Master' ]]; then
+  apt-get update
+  apt-get install -y -q docker.io
+  if [[ -z "${DOCKER_IMAGE}" ]]; then
+    DOCKER_IMAGE="gcr.io/cloud-datalab/datalab:local"
+  fi
+  gcloud docker -- pull ${DOCKER_IMAGE}
+
+  # For some reason Spark has issues resolving the user's directory inside of
+  # Datalab.
+  # TODO(pmkc) consider fixing in Dataproc proper.
+  SPARK_CONF='/etc/spark/conf/spark-defaults.conf'
+  if ! grep -q '^spark\.sql\.warehouse\.dir=' "${SPARK_CONF}"; then
+    echo 'spark.sql.warehouse.dir=/root/spark-warehouse' >> "${SPARK_CONF}"
+  fi
+
+  DATALAB_DIR="${HOME}/datalab"
+  mkdir -p "${DATALAB_DIR}"
+
+  # Expose every possbile spark libary to the container.
+  VOLUME_FLAGS=$(echo {/usr/bin,/usr/lib,/etc,/etc/alternatives,/var/log}/{hadoop*,hive*,*spark*} \
+      /hadoop* /usr/lib/jvm/ /usr/share/java/ /usr/lib/bigtop* \
+      | sed 's/\S*/-v &:&/g')
+  echo "VOLUME_FLAGS: ${VOLUME_FLAGS}"
+
+  PYTHONPATH="/env/python:$(find /usr/lib/spark/python/lib -name '*.zip' | paste -sd:)"
+  # Using this many volumes, each containing symlinks, often gives a "too many
+  # symlinks" error. Just retry till it works.
+  for i in {1..10}; do
+    if docker run -d --net=host -v "${DATALAB_DIR}:/content/datalab" ${VOLUME_FLAGS} \
+        -e "SPARK_HOME=/usr/lib/spark" \
+        -e "JAVA_HOME=${JAVA_HOME}" \
+        -e "PYTHONPATH=${PYTHONPATH}" \
+        -e "PYTHONSTARTUP=/usr/lib/spark/python/pyspark/shell.py" \
+        -e "DATALAB_ENV=GCE" \
+        ${DOCKER_IMAGE}; then
+      echo 'Cloud Datalab Jupyter server successfully deployed.'
+      exit
+    fi
+    sleep 1
+  done
+
+  echo 'Failed to run Cloud Datalab' >&2
+  exit 1
+fi

--- a/initialization-actions/drill/README.md
+++ b/initialization-actions/drill/README.md
@@ -1,0 +1,63 @@
+# Apache Drill Initialization Action
+
+This initialization action installs [Apache Drill](http://drill.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. The script will also start drillbits on all nodes of the cluster.
+
+## Using this initialization action
+
+Check the variables set in the script to ensure they're to your liking.
+
+Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Drill installed by:
+
+1. Uploading a copy of the [initialization action for zookeeper](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/zookeeper) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Uploading a copy of the initialization action (`drill.sh`) to GCS.
+1. Using the `gcloud` command to create a new cluster with zookeeper and this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/zookeeper.sh,gs://<GCS_BUCKET>/drill.sh
+    --initialization-action-timeout 5m
+    ```
+1. Once the cluster has been created, Drillbits will start on all nodes. You can log into any node of the cluster to run Drill queries. Drill is installed in `/usr/lib/drill` (unless you change the setting) which contains a `bin` directory with `sqlline`.
+
+You can run the following to get into sqlline, the Drill CLI query tool:
+
+`sudo -u drill /usr/lib/drill/bin/sqlline -u jdbc:drill:`
+
+If you prefer to run drill as your user, set `DRILL_LOG_DIR` to someplace you have permission to write to:
+
+`DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:`
+
+Once in sqlline, you can see what storage plugins are available. Out of the box, this initialization action supports GCS (gs), HDFS (hdfs), local linux file system (dfs) and Hive (hive):
+
+```
+$ DRILL_LOG_DIR=~/logs /usr/lib/drill/bin/sqlline -u jdbc:drill:
+OpenJDK 64-Bit Server VM warning: ignoring option MaxPermSize=512M; support was removed in 8.0
+apache drill 1.9.0
+"just drill it"
+0: jdbc:drill:> show databases;
++---------------------+
+|     SCHEMA_NAME     |
++---------------------+
+| INFORMATION_SCHEMA  |
+| cp.default          |
+| dfs.default         |
+| dfs.root            |
+| dfs.tmp             |
+| gs.default          |
+| gs.root             |
+| hdfs.default        |
+| hdfs.root           |
+| hdfs.tmp            |
+| hive.default        |
+| sys                 |
++---------------------+
+12 rows selected (3.943 seconds)
+```
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script must be updated based on which Drill version you wish you install
+* This script must be updated based on your Cloud Dataproc cluster
+* Access to the Drill UI is possible via SSH forwarding to port 8047 on any drillbit, or with a [SOCKS proxy via SSH](https://cloud.google.com/solutions/connecting-securely#socks-proxy-over-ssh).
+* By default your Drill query profiles are stored in GCS in your cluster's dataproc bucket, as returned by `/usr/share/google/get_metadata_value attributes/dataproc-bucket`. You can change this in `drill.sh`.

--- a/initialization-actions/drill/drill.sh
+++ b/initialization-actions/drill/drill.sh
@@ -1,0 +1,227 @@
+#!/bin/bash
+set -x -e
+
+# where we should install drill
+DRILL_USER=drill
+DRILL_USER_HOME=/var/lib/drill
+DRILL_HOME=/usr/lib/drill
+DRILL_LOG_DIR=/var/log/drill
+DRILL_VERSION="1.9.0"
+
+
+# Determine the role of this node
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+# Determine the cluster name
+CLUSTER=$(/usr/share/google/get_metadata_value attributes/dataproc-cluster-name)
+
+# Change these if you have a GCS bucket you'd like to use instead.
+DATAPROC_BUCKET=$(/usr/share/google/get_metadata_value attributes/dataproc-bucket)
+PROFILE_STORE="gs://$DATAPROC_BUCKET/profiles"
+GS_PLUGIN_BUCKET="gs://$DATAPROC_BUCKET"
+
+# naively generate the zookeeper string
+ZK=$CLUSTER-m:2181,$CLUSTER-w-0:2181,$CLUSTER-w-1:2181
+
+# Create drill pseudo-user.
+useradd -r -m -d $DRILL_USER_HOME $DRILL_USER || echo
+
+# Create drill home
+mkdir -p $DRILL_HOME && chown $DRILL_USER:$DRILL_USER $DRILL_HOME
+
+# Download and unpack Drill as the pseudo-user.
+curl -L http://apache.mirrors.lucidnetworks.net/drill/drill-$DRILL_VERSION/apache-drill-$DRILL_VERSION.tar.gz | sudo -u $DRILL_USER tar --strip-components=1 -C $DRILL_HOME -vxzf -
+
+# Replace default configuration with cluster-specific.
+sed -i "s/drillbits1/$CLUSTER/" $DRILL_HOME/conf/drill-override.conf
+sed -i "s/localhost:2181/$ZK/" $DRILL_HOME/conf/drill-override.conf
+
+# Make the log directory
+mkdir -p $DRILL_LOG_DIR && chown $DRILL_USER:$DRILL_USER $DRILL_LOG_DIR
+
+# Symlink drill conf dir to /etc
+mkdir -p /etc/drill && ln -sf $DRILL_HOME/conf /etc/drill/
+
+# Point drill logs to $DRILL_LOG_DIR
+echo DRILL_LOG_DIR=$DRILL_LOG_DIR >> $DRILL_HOME/conf/drill-env.sh
+
+# Copy GCS connector to drill jars
+ln -sf /usr/lib/hadoop/lib/gcs-connector-1.6.0-hadoop2.jar $DRILL_HOME/jars/3rdparty
+
+# Symlink core-site.xml to $DRILL_HOME/conf
+ln -sf /etc/hadoop/conf/core-site.xml /etc/drill/conf
+
+# Set ZK PStore to use a GCS Bucket
+# Makes all Drill profiles available from any drillbit
+cat >> $DRILL_HOME/conf/drill-override.conf <<EOF
+drill.exec: { sys.store.provider.zk.blobroot: "$PROFILE_STORE" }
+EOF
+
+# Start drillbit
+sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh status ||\
+	sudo -u $DRILL_USER $DRILL_HOME/bin/drillbit.sh start && sleep 10
+
+# Create the hive storage plugin
+cat > /tmp/hive_plugin.json <<EOF
+{
+"name": "hive",
+"config": {
+    "type": "hive",
+    "enabled": true,
+    "configProps": {
+    "hive.metastore.uris": "thrift://$CLUSTER-m:9083",
+    "hive.metastore.sasl.enabled": "false",
+    "fs.default.name": "hdfs://$CLUSTER-m/"
+    }
+  }
+}
+EOF
+
+# Create GCS storage plugin
+cat > /tmp/gcs_plugin.json <<EOF
+{
+    "config": {
+        "connection": "$GS_PLUGIN_BUCKET",
+        "enabled": true,
+        "formats": {
+            "avro": {
+                "type": "avro"
+            },
+            "csv": {
+                "delimiter": ",",
+                "extensions": [
+                    "csv"
+                ],
+                "type": "text"
+            },
+            "csvh": {
+                "delimiter": ",",
+                "extensions": [
+                    "csvh"
+                ],
+                "extractHeader": true,
+                "type": "text"
+            },
+            "json": {
+                "extensions": [
+                    "json"
+                ],
+                "type": "json"
+            },
+            "parquet": {
+                "type": "parquet"
+            },
+            "psv": {
+                "delimiter": "|",
+                "extensions": [
+                    "tbl"
+                ],
+                "type": "text"
+            },
+            "sequencefile": {
+                "extensions": [
+                    "seq"
+                ],
+                "type": "sequencefile"
+            },
+            "tsv": {
+                "delimiter": "\t",
+                "extensions": [
+                    "tsv"
+                ],
+                "type": "text"
+            }
+        },
+        "type": "file",
+        "workspaces": {
+            "root": {
+                "defaultInputFormat": null,
+                "location": "/",
+                "writable": true
+            }
+        }
+    },
+    "name": "gs"
+}
+EOF
+
+# Create/Update hdfs storage plugin
+cat > /tmp/hdfs_plugin.json <<EOF
+{
+    "config": {
+        "connection": "hdfs://$CLUSTER-m",
+        "enabled": true,
+        "formats": {
+            "avro": {
+                "type": "avro"
+            },
+            "csv": {
+                "delimiter": ",",
+                "extensions": [
+                    "csv"
+                ],
+                "type": "text"
+            },
+            "csvh": {
+                "delimiter": ",",
+                "extensions": [
+                    "csvh"
+                ],
+                "extractHeader": true,
+                "type": "text"
+            },
+            "json": {
+                "extensions": [
+                    "json"
+                ],
+                "type": "json"
+            },
+            "parquet": {
+                "type": "parquet"
+            },
+            "psv": {
+                "delimiter": "|",
+                "extensions": [
+                    "tbl"
+                ],
+                "type": "text"
+            },
+            "sequencefile": {
+                "extensions": [
+                    "seq"
+                ],
+                "type": "sequencefile"
+            },
+            "tsv": {
+                "delimiter": "\t",
+                "extensions": [
+                    "tsv"
+                ],
+                "type": "text"
+            }
+        },
+        "type": "file",
+        "workspaces": {
+            "root": {
+                "defaultInputFormat": null,
+                "location": "/",
+                "writable": false
+            },
+            "tmp": {
+                "defaultInputFormat": null,
+                "location": "/tmp",
+                "writable": true
+            }
+        }
+    },
+    "name": "hdfs"
+}
+EOF
+
+curl -d@/tmp/hive_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/hive.json
+curl -d@/tmp/gcs_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/gs.json
+curl -d@/tmp/hdfs_plugin.json -H "Content-Type: application/json" -X POST http://localhost:8047/storage/hdfs.json
+
+# Clean up
+rm -f /tmp/*_plugin.json
+
+set +x +e

--- a/initialization-actions/flink/README.md
+++ b/initialization-actions/flink/README.md
@@ -1,0 +1,36 @@
+# Apache Flink Initialization Action
+
+This initialization action installs a binary release of [Apache Flink](http://flink.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. Additionally, this script will tune some basic parameters for
+Flink and start a Flink session running on YARN.
+
+## Using this initialization action
+To use this initialization action, you will likely need to configure a few settings in the initialization action. Specifically, you shoud modify the following variables to match your desired setup:
+
+* `SCALA_VERSION` - The Scala version installed on the Cloud Dataproc cluster
+* `HADOOP_VERSION` - The Hadoop version installed on the Cloud Dataproc cluster
+* `FLINK_VERSION` - The Flink version to be installed
+
+The `SCALA_VERSION` and `HADOOP_VERSION` will be based on the [Cloud Dataproc image version](https://cloud.google.com/dataproc/concepts/dataproc-versions) you select. The `NUM_WORKERS` will be based on the number of workers you add to your cluster.
+
+Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster with Flink installed by:
+
+1. Uploading a copy of the initialization action (`flink.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/flink.sh   
+    --initialization-action-timeout 5m
+    ```
+1. Once the cluster has been created, Flink will start a session on YARN. You can log into the master node of the cluster to submit jobs to Flink. Flink is installed in `/usr/lib/flink` (unless you change the setting) which contains a `bin` directory with Flink. **Note** - you need to specify `HADOOP_CONF_DIR=/etc/hadoop/conf` before your Flink commands for them to execute properly.
+
+For example, this command will run a word count sample (as root):
+
+`sudo su -
+HADOOP_CONF_DIR=/etc/hadoop/conf /usr/lib/flink/bin/flink run -m yarn-cluster examples/streaming/WordCount.jar`
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script must be updated based on which Flink version you wish you install
+* This script must be updated based on your Cloud Dataproc cluster

--- a/initialization-actions/flink/flink.sh
+++ b/initialization-actions/flink/flink.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script installs Apache Flink (http://flink.apache.org) on a Google Cloud
+# Dataproc cluster. This script is based on previous scripts:
+# https://github.com/GoogleCloudPlatform/bdutil/tree/master/extensions/flink
+#
+# To use this script, you will need to configure the following variables to
+# match your cluster. For information about which software components
+# (and their version) are included in Cloud Dataproc clusters, see the
+# Cloud Dataproc Image Version information:
+# https://cloud.google.com/dataproc/concepts/dataproc-versions
+
+set -x -e
+
+# Install directories for Flink and Hadoop
+readonly FLINK_INSTALL_DIR='/usr/lib/flink'
+readonly HADOOP_CONF_DIR='/etc/hadoop/conf'
+
+# The number of buffers for the network stack
+# Flink config entry: taskmanager.network.numberOfBuffers
+readonly FLINK_NETWORK_NUM_BUFFERS=2048
+
+# Heap memory used by the job manager (master) determined by the physical (free) memory of the server
+# Flink config entry: jobmanager.heap.mb
+readonly FLINK_JOBMANAGER_MEMORY_FRACTION='1.0'
+
+# Heap memory used by the task managers (slaves) determined by the physical (free) memory of the servers
+# Flink config entry: taskmanager.heap.mb
+readonly FLINK_TASKMANAGER_MEMORY_FRACTION='1.0'
+
+# Set this to true to start a flink yarn session at initialization time.
+readonly START_FLINK_YARN_SESSION="true"
+
+function configure_flink() {
+  # Number of worker nodes in your cluster
+  local num_workers=$(/usr/share/google/get_metadata_value attributes/dataproc-worker-count)
+
+  # Number of Flink TaskManagers to use. Reserve 1 node for the JobManager.
+  # NB: This assumes > 1 worker node.
+  local num_taskmanagers="$(($num_workers - 1))"
+
+  # Determine the number of task slots per worker.
+  # TODO: Dataproc does not currently set the number of worker cores on the
+  # master node. However, the spark configuration sets the number of executors
+  # to be half the number of CPU cores per worker. We use this value to
+  # determine the number of worker cores. Fix this hack when
+  # yarn.nodemanager.resource.cpu-vcores is correctly populated.
+  local spark_executor_cores=$(\
+    grep 'spark\.executor\.cores' /etc/spark/conf/spark-defaults.conf \
+    | tail -n1 | cut -d'=' -f2)
+  local flink_taskmanager_slots="$(($spark_executor_cores * 2))"
+  # local flink_taskmanager_slots="$(hdfs getconf \
+  #   -confKey yarn.nodemanager.resource.cpu-vcores)"
+
+  # Determine the default parallelism
+  local flink_parallelism=$(python -c \
+      "print ${num_taskmanagers} * ${flink_taskmanager_slots}")
+
+  # Get worker memory from yarn config.
+  local worker_total_mem="$(hdfs getconf \
+    -confKey yarn.nodemanager.resource.memory-mb)"
+  local flink_jobmanager_memory=$(python -c \
+      "print int(${worker_total_mem} * ${FLINK_JOBMANAGER_MEMORY_FRACTION})")
+  local flink_taskmanager_memory=$(python -c \
+      "print int(${worker_total_mem} * ${FLINK_TASKMANAGER_MEMORY_FRACTION})")
+
+  # Apply Flink settings by appending them to the default config
+  cat << EOF >> ${FLINK_INSTALL_DIR}/conf/flink-conf.yaml
+# Settings applied by Cloud Dataproc initialization action
+jobmanager.rpc.address: ${MASTER_HOSTNAME}
+jobmanager.heap.mb: ${flink_jobmanager_memory}
+taskmanager.heap.mb: ${flink_taskmanager_memory}
+taskmanager.numberOfTaskSlots: ${flink_taskmanager_slots}
+parallelism.default: ${flink_parallelism}
+taskmanager.network.numberOfBuffers: ${FLINK_NETWORK_NUM_BUFFERS}
+fs.hdfs.hadoopconf: ${HADOOP_CONF_DIR}
+EOF
+
+  if [ "${START_FLINK_YARN_SESSION}" = 'true' ] ; then
+    # NB: yarn-session.sh ignores taskmanager.numberOfTaskSlots for some reason.
+    # We specify it manually below.
+    env HADOOP_CONF_DIR="$HADOOP_CONF_DIR" \
+      "$FLINK_INSTALL_DIR/bin/yarn-session.sh" \
+      -n "${num_taskmanagers}" \
+      -s "${flink_taskmanager_slots}" \
+      -jm "${flink_jobmanager_memory}" \
+      -tm "${flink_taskmanager_memory}" \
+      --detached
+  fi
+
+}
+
+function main() {
+local role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+if [[ "${role}" == 'Master' ]]; then
+  apt-get install -y flink
+  configure_flink
+fi
+}
+
+main
+
+set +x +e

--- a/initialization-actions/ganglia/README.MD
+++ b/initialization-actions/ganglia/README.MD
@@ -1,0 +1,6 @@
+# Ganglia
+
+This initialization action installs [Ganglia](http://ganglia.info/).
+
+Ganglia is configured to run on port `80` on the master node in a Dataproc cluster.
+Access it at: http://masterip/ganglia

--- a/initialization-actions/ganglia/ganglia.sh
+++ b/initialization-actions/ganglia/ganglia.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#    Copyright 2015 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+set -x -e
+
+apt-get update && apt-get install -y ganglia-monitor
+
+MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
+
+sed -e "/name = \"unspecified\" /s/unspecified/$MASTER/" -i /etc/ganglia/gmond.conf
+sed -e '/mcast_join /s/^  /  #/' -i /etc/ganglia/gmond.conf
+sed -e '/bind /s/^  /  #/' -i /etc/ganglia/gmond.conf
+
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+if [[ "${ROLE}" == 'Master' ]]; then
+    # Only run on the master node
+    # Install dependencies needed for ganglia
+    DEBIAN_FRONTEND=noninteractive apt install -y rrdtool gmetad ganglia-webfrontend
+    cp /etc/ganglia-webfrontend/apache.conf /etc/apache2/sites-enabled/ganglia.conf
+
+    sed -i "s/my cluster/$MASTER/" /etc/ganglia/gmetad.conf
+    sed -e '/udp_send_channel {/a\  host = localhost' -i /etc/ganglia/gmond.conf
+
+    service ganglia-monitor restart && service gmetad restart && service apache2 restart
+
+else
+
+    sed -e "/udp_send_channel {/a\  host = $MASTER" -i /etc/ganglia/gmond.conf
+    sed -i '/udp_recv_channel {/,/}/d' /etc/ganglia/gmond.conf
+    service ganglia-monitor restart
+
+fi

--- a/initialization-actions/hive-hcatalog/README.md
+++ b/initialization-actions/hive-hcatalog/README.md
@@ -1,0 +1,18 @@
+# HCatalog initialization action
+
+This initialization action installs [Hive HCatalog](https://cwiki.apache.org/confluence/display/Hive/HCatalog) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. The script will also configure Pig to use HCatalog.
+
+## Using this initialization action
+
+You can use this initialization action to create a new Cloud Dataproc cluster with HCatalog installed by doing the following.
+
+1. Uploading a copy of this initialization action (`hive-hcatalog.sh`) to [Google Cloud Storage](https://cloud.google.com/storage). Alternatively, you can use the Google-hosted copy of this initialization action at `gs://dataproc-initialization-actions/hive-hcatalog/hive-hcatalog.sh`
+2. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER-NAME>`, specify the initialization action stored in `<GCS-BUCKET>`:
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER-NAME> \
+    --initialization-actions gs://<GCS-BUCKET>/hive-hcatalog.sh
+    ```
+3. Once the cluster has been created HCatalog should be installed and configured for use with Pig.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).

--- a/initialization-actions/hive-hcatalog/hive-hcatalog.sh
+++ b/initialization-actions/hive-hcatalog/hive-hcatalog.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script installs Hive HCatalog
+# (https://cwiki.apache.org/confluence/display/Hive/HCatalog) on a Google Cloud
+# Dataproc cluster.
+#
+# To use this script, you will need to configure the following variables to
+# match your cluster. For information about which software components
+# (and their version) are included in Cloud Dataproc clusters, see the
+# Cloud Dataproc Image Version information:
+# https://cloud.google.com/dataproc/concepts/dataproc-versions
+
+set -x -e
+
+# Install the hive-hcatalog package
+apt-get -q -y install hive-hcatalog
+
+# Configure Pig to use HCatalog
+cat >>/etc/pig/conf/pig-env.sh <<EOF
+#!/bin/bash
+
+includeHCatalog=true
+
+EOF

--- a/initialization-actions/hue/README.md
+++ b/initialization-actions/hue/README.md
@@ -1,0 +1,19 @@
+# HUE - Hadoop User Experience 
+
+This [initialization action] (https://cloud.google.com/dataproc/init-actions) installs the latest version of [HUE](http://gethue.com/) 
+on a master node within a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Hue installed by:
+
+1. Uploading a copy of this initialization action (`hue.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+2. Using the `gcloud` command to create a new cluster with this initialization action.  The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/hue.sh   
+    ```
+Alternatively, you can start a regular dataproc cluster, [ssh to the master node]  (https://cloud.google.com/dataproc/submit-job) (see SSH into instance), clone this repository and run ./hue.sh (as sudo) 
+
+3. Once the cluster has been created, Hue is configured to run on port `8888` on the master node in a Dataproc cluster. To connect to the Hue web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy with your web browser as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation. 
+In the opened web browser go to 'localhost:8888' and you should see the Hue UI.

--- a/initialization-actions/hue/hue.sh
+++ b/initialization-actions/hue/hue.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -x -e
+
+# Determine the role of this node
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+
+
+# Only run on the master node of the cluster
+if [[ "${ROLE}" == 'Master' ]]; then
+  apt-get update
+  apt-get install hue -y
+
+  cat > core-site-patch.xml <<EOF
+  <property> 
+    <name>hadoop.proxyuser.hue.hosts</name> 
+    <value>*</value> 
+  </property> 
+  <property> 
+    <name>hadoop.proxyuser.hue.groups</name> 
+    <value>*</value> 
+  </property> 
+EOF
+  sed -i '/<\/configuration>/e cat core-site-patch.xml' \
+     /etc/hadoop/conf/core-site.xml
+  
+ 
+  cat > hdfs-site-patch.xml <<EOF
+  <property>
+    <name>dfs.webhdfs.enabled</name>
+    <value>true</value>
+  </property>
+  
+  <property>
+    <name>hadoop.proxyuser.hue.hosts</name>
+    <value>*</value>
+  </property>
+  
+  <property>
+    <name>hadoop.proxyuser.hue.groups</name>
+    <value>*</value>
+  </property>
+EOF
+
+  sed -i '/<\/configuration>/e cat hdfs-site-patch.xml' \
+       /etc/hadoop/conf/hdfs-site.xml
+       
+  cat >> /etc/hue/conf/hue.ini <<EOF
+    # Defaults to $HADOOP_MR1_HOME or /usr/lib/hadoop-0.20-mapreduce
+    hadoop_mapred_home=/usr/lib/hadoop-mapreduce 
+EOF
+       
+  # Replace localhost with hostname.
+  sed -i "s/#*\([^#]*=.*\)localhost/\1$(hostname --fqdn)/" /etc/hue/conf/hue.ini
+
+  # Clean up temporary fles
+  rm -rf hdfs-site-patch.xml core-site-patch.xml hue-patch.ini
+
+  # Restart HDFS
+  /usr/lib/hadoop/libexec/init-hdfs.sh
+
+  # Restart Hue
+  service hue restart
+fi
+
+set +x +e

--- a/initialization-actions/ipython-notebook/README.MD
+++ b/initialization-actions/ipython-notebook/README.MD
@@ -1,0 +1,3 @@
+# iPython Notebook
+
+This initialization action installs [iPython Notebook](http://ipython.org/notebook.html). iPython is configured to run on port `8123` on the master node in a Dataproc cluster. To connect to the iPython Notebook web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.

--- a/initialization-actions/ipython-notebook/ipython.sh
+++ b/initialization-actions/ipython-notebook/ipython.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#    Copyright 2015 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+set -e -x
+
+# Only run on the master node
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+if [[ "${ROLE}" == 'Master' ]]; then
+
+	# Install dependencies needed for iPython Notebook
+	apt-get install build-essential python-dev libpng-dev libfreetype6-dev libxft-dev pkg-config python-matplotlib python-requests python-numpy -y
+	curl https://bootstrap.pypa.io/get-pip.py | python
+
+	# Install iPython Notebook and create a profile
+	mkdir IPythonNB
+	cd IPythonNB
+	pip install "ipython[notebook]"
+	ipython profile create default
+
+	# Set up configuration for iPython Notebook
+	echo "c = get_config()" >  /root/.ipython/profile_default/ipython_notebook_config.py
+	echo "c.NotebookApp.ip = '*'" >>  /root/.ipython/profile_default/ipython_notebook_config.py
+	echo "c.NotebookApp.open_browser = False"  >>  /root/.ipython/profile_default/ipython_notebook_config.py
+	echo "c.NotebookApp.port = 8123" >>  /root/.ipython/profile_default/ipython_notebook_config.py
+
+	# Setup script for iPython Notebook so it uses the cluster's Spark
+	cat > /root/.ipython/profile_default/startup/00-pyspark-setup.py <<'_EOF'
+import os
+import sys
+
+spark_home = '/usr/lib/spark/'
+os.environ["SPARK_HOME"] = spark_home
+sys.path.insert(0, os.path.join(spark_home, 'python'))
+sys.path.insert(0, os.path.join(spark_home, 'python/lib/py4j-0.9-src.zip'))
+execfile(os.path.join(spark_home, 'python/pyspark/shell.py'))
+_EOF
+
+	# Start iPython Notebook on port 8123
+	nohup ipython notebook --no-browser --ip=* --port=8123 > /var/log/python_notebook.log &
+fi

--- a/initialization-actions/jupyter/README.MD
+++ b/initialization-actions/jupyter/README.MD
@@ -1,0 +1,70 @@
+# Jupyter Notebook
+
+This folder contains the initialization action `jupyter.sh` to quickly setup and launch [Jupyter Notebook](http://jupyter.org/), (the successor of IPython notebook) and a script to be run on the user's local machine to access the Jupyter notebook server.
+
+A real-world example of how to use this from within a bash script, using the default dataproc-initialization-actions repo/branch:
+
+```bash
+# Simple one-liner; just use all default settings for your cluster. Jupyter will run on port 8123
+# of your master node.
+gcloud dataproc clusters create my-dataproc-cluster \
+    --initialization-actions \
+        gs://dataproc-initialization-actions/jupyter/jupyter.sh \
+```
+
+There are various options for customizing your Jupyter installation. For example to change the port
+on which the Jupyter server runs, you can set the metadata key `JUPYTER_PORT`. You may also want
+to change the number of workers and machine type of your cluster:
+
+```bash
+# Override the Jupyter port with 8124 (default is 8123)
+gcloud dataproc clusters create my-dataproc-cluster \
+    --metadata "JUPYTER_PORT=8124" \
+    --initialization-actions \
+        gs://dataproc-initialization-actions/jupyter/jupyter.sh \
+    --num-workers 2 \
+    --properties spark:spark.executorEnv.PYTHONHASHSEED=0,spark:spark.yarn.am.memory=1024m \
+    --worker-machine-type=n1-standard-4 \
+    --master-machine-type=n1-standard-4
+```
+You can pre-install various Python packages through `conda` by specifying a colon-separated
+list in the metadata entry `JUPYTER_CONDA_PACKAGES`:
+
+```bash
+gcloud dataproc clusters create my-dataproc-cluster \
+    --metadata "JUPYTER_PORT=8124,JUPYTER_CONDA_PACKAGES=numpy:pandas:scikit-learn" \
+    --initialization-actions \
+        gs://dataproc-initialization-actions/jupyter/jupyter.sh \
+    --num-workers 2 \
+    --properties spark:spark.executorEnv.PYTHONHASHSEED=0,spark:spark.yarn.am.memory=1024m \
+    --worker-machine-type=n1-standard-4 \
+    --master-machine-type=n1-standard-4
+```
+
+## jupyter.sh
+
+`jupyter.sh` handles configuring and running Jupyter on the Dataproc master node by doing the following:
+
+- clones the dataproc-initialization-actions git repo/branch specified in the `INIT_ACTIONS_REPO` and `INIT_ACTIONS_BRANCH` metadata keys
+  - if these two metadata keys are not set during cluster creation, the default values `https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git` and `master` are used
+  - this is provided so that a fork/branch of the main repo can easily be used, eg, during development
+- executes `conda/bootstrap-conda.sh` from said repo/branch to ensure `miniconda` is available
+- executes `jupyter/internal/setup-jupyter-kernel.sh` and `jupyter/internal/launch-jupyter-kernel.sh` from said repo/branch
+  - configures `jupyter` to use the *PySpark* kernel found at `jupyter/kernels/pyspark/kernel.json`
+  - configures `jupyter` to listen on the port specified by the metadata key `JUPYTER_PORT`, with a default value of `8123`
+  - targets a default notebooks directory `/root/notebooks`, into which the directory found at `gs://$DATAPROC_BUCKET/notebooks/` is copied, where `$DATAPROC_BUCKET` is the value stored in the metadata key `dataproc-bucket` (set by default upon cluster creation and overridable)
+  - launches the `jupyter notebook` process
+
+**NOTE**: to be run as an init action.
+
+
+## launch-jupyter-interface.sh
+
+`launch-jupyter-interface.sh` launches a web interface to connect to Jupyter notebook process running on master node.
+
+- sets a path for the local OS to the Chrome executable
+- setup an ssh tunnel and socks proxy to the master node
+- launch a Chrome instance that uses this ssh tunnel and references the Jupyter port.
+
+**NOTE**: to be run from a local machine
+ 

--- a/initialization-actions/jupyter/internal/bootstrap-jupyter-ext.sh
+++ b/initialization-actions/jupyter/internal/bootstrap-jupyter-ext.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+sudo apt-get install -y git
+
+# Installs Jupyter notebook extensions and RISE
+# https://github.com/ipython-contrib/IPython-notebook-extensions
+
+# 0. Ensure local Jupyter / IPython (~/.local/) dir exists.
+
+# Simple hack to circumvent exception when .local directory does not yet exist:
+# > OSError: [Errno 2] No such file or directory:
+# > '/home/vagrant/.local/share/jupyter'
+# > Command failed: /bin/bash -x -e
+# > /home/vagrant/miniconda-3.18.3/conda-bld/work/conda_build.sh
+# If directory doesn't exist, attempt to create it.
+if [[ ! -d "~/.local/share/jupyter/" ]]
+then
+  echo "~/.local/share/jupyter/ directory does not exist, creating..."
+  mkdir -p ~/.local/share/jupyter/
+  echo "~/.local/share/jupyter/ directory created, continuing..."
+fi
+
+# 1. Install IPyNB extensions:
+nbext_path='IPython-notebook-extensions'
+if [[ ! -d $nbext_path ]]
+then
+    echo "Installing $nbext_path"
+    git clone https://github.com/ipython-contrib/IPython-notebook-extensions.git
+    conda build IPython-notebook-extensions
+    conda install --use-local nbextensions
+else
+    echo "Existing directory at path: $nbext_path, skipping install!"
+fi
+
+# 2. Install RISE (http://github.com/damianavila/RISE)
+rise_path='RISE'
+if [[ ! -d $rise_path ]]
+then
+    echo "Installing $rise_path"
+    git clone https://github.com/damianavila/RISE.git
+    cd RISE && python setup.py install
+else
+    echo "Existing directory at path: $rise_path, skipping install!"
+fi
+

--- a/initialization-actions/jupyter/internal/launch-jupyter-kernel.sh
+++ b/initialization-actions/jupyter/internal/launch-jupyter-kernel.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Starting Jupyter notebook..."
+nohup jupyter notebook --no-browser > /var/log/jupyter_notebook.log 2>&1 &
+

--- a/initialization-actions/jupyter/internal/setup-jupyter-kernel.sh
+++ b/initialization-actions/jupyter/internal/setup-jupyter-kernel.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+DIR="${BASH_SOURCE%/*}"
+[[ ! -d "$DIR" ]] && DIR="$PWD"
+source "$DIR/../../util/utils.sh"
+
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+JUPYTER_NOTEBOOK_DIR="/root/notebooks"
+JUPYTER_PORT=$(/usr/share/google/get_metadata_value attributes/JUPYTER_PORT || true)
+[[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && JUPYTER_PORT=8123
+JUPYTER_AUTH_TOKEN=$(/usr/share/google/get_metadata_value attributes/JUPYTER_AUTH_TOKEN || true)
+JUPYTER_IP=*
+
+[[ "${ROLE}" != 'Master' ]] && throw "$0 should only be run on the Master node!"
+
+echo "Creating notebook directory $JUPYTER_NOTEBOOK_DIR if necessary..."
+[[ ! -d $JUPYTER_NOTEBOOK_DIR ]] && mkdir -p $JUPYTER_NOTEBOOK_DIR
+
+echo "Creating Jupyter config..."
+jupyter notebook --generate-config -y --ip=127.0.0.1
+echo "c.Application.log_level = 'DEBUG'" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.ip = '*'" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.open_browser = False" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.port = $JUPYTER_PORT" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.notebook_dir = '$JUPYTER_NOTEBOOK_DIR'" >> ~/.jupyter/jupyter_notebook_config.py
+echo "c.NotebookApp.token = u'$JUPYTER_AUTH_TOKEN'" >> ~/.jupyter/jupyter_notebook_config.py
+
+echo "Installing pyspark Kernel..."
+JUPYTER_KERNEL_DIR='/dataproc-initialization-actions/jupyter/kernels/pyspark'
+KERNEL_GENERATOR='/dataproc-initialization-actions/jupyter/kernels/generate_pyspark.sh'
+chmod 750 ${KERNEL_GENERATOR}
+mkdir -p ${JUPYTER_KERNEL_DIR}
+${KERNEL_GENERATOR} > "${JUPYTER_KERNEL_DIR}/kernel.json"
+jupyter kernelspec install $JUPYTER_KERNEL_DIR
+echo "c.MappingKernelManager.default_kernel_name = 'pyspark'" >> ~/.jupyter/jupyter_notebook_config.py
+
+echo "Jupyter setup!"
+

--- a/initialization-actions/jupyter/jupyter.sh
+++ b/initialization-actions/jupyter/jupyter.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -e
+
+ROLE=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-role)
+INIT_ACTIONS_REPO=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/INIT_ACTIONS_REPO || true)
+INIT_ACTIONS_REPO="${INIT_ACTIONS_REPO:-https://github.com/GoogleCloudPlatform/dataproc-initialization-actions.git}"
+INIT_ACTIONS_BRANCH=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/INIT_ACTIONS_BRANCH || true)
+INIT_ACTIONS_BRANCH="${INIT_ACTIONS_BRANCH:-master}"
+DATAPROC_BUCKET=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/dataproc-bucket)
+
+# Colon-separated list of conda packages to install, for example 'numpy:pandas'
+JUPYTER_CONDA_PACKAGES=$(curl -f -s -H Metadata-Flavor:Google http://metadata/computeMetadata/v1/instance/attributes/JUPYTER_CONDA_PACKAGES || true)
+
+echo "Cloning fresh dataproc-initialization-actions from repo $INIT_ACTIONS_REPO and branch $INIT_ACTIONS_BRANCH..."
+git clone -b "$INIT_ACTIONS_BRANCH" --single-branch $INIT_ACTIONS_REPO
+# Ensure we have conda installed.
+./dataproc-initialization-actions/conda/bootstrap-conda.sh
+#./dataproc-initialization-actions/conda/install-conda-env.sh
+
+source /etc/profile.d/conda_config.sh
+
+if [ -n "${JUPYTER_CONDA_PACKAGES}" ]; then
+  echo "Installing custom conda packages '$(echo ${JUPYTER_CONDA_PACKAGES} | tr ':' ' ')'"
+  conda install $(echo ${JUPYTER_CONDA_PACKAGES} | tr ':' ' ')
+fi
+
+if [[ "${ROLE}" == 'Master' ]]; then
+    conda install jupyter
+    if gsutil -q stat "gs://$DATAPROC_BUCKET/notebooks/**"; then
+        echo "Pulling notebooks directory to cluster master node..."
+        gsutil -m cp -r gs://$DATAPROC_BUCKET/notebooks /root/
+    fi
+    ./dataproc-initialization-actions/jupyter/internal/setup-jupyter-kernel.sh
+    ./dataproc-initialization-actions/jupyter/internal/launch-jupyter-kernel.sh
+fi
+echo "Completed installing Jupyter!"
+
+# Install Jupyter extensions (if desired)
+# TODO: document this in readme
+if [[ ! -v $INSTALL_JUPYTER_EXT ]]
+    then
+    INSTALL_JUPYTER_EXT=false
+fi
+if [[ "$INSTALL_JUPYTER_EXT" = true ]]
+then
+    echo "Installing Jupyter Notebook extensions..."
+    ./dataproc-initialization-actions/jupyter/internal/bootstrap-jupyter-ext.sh
+    echo "Jupyter Notebook extensions installed!"
+fi
+

--- a/initialization-actions/jupyter/kernels/generate_pyspark.sh
+++ b/initialization-actions/jupyter/kernels/generate_pyspark.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Prints a generated JSON spec in to stdout which can be used to configure a
+# pyspark Jupyter kernel, based on various version settings like the installed
+# spark version.
+
+set -e
+
+SPARK_MAJOR_VERSION=$(spark-submit --version |& \
+    grep 'version' | head -n 1 | sed 's/.*version //' | cut -d '.' -f 1)
+echo "Determined SPARK_MAJOR_VERSION to be '${SPARK_MAJOR_VERSION}'" >&2
+
+# This will let us exit with error code if not found.
+PY4J_ZIP=$(ls /usr/lib/spark/python/lib/py4j-*.zip)
+
+# In case there are multiple py4j versions or unversioned symlinks to the
+# versioned file, just choose the first one to use for jupyter.
+PY4J_ZIP=$(echo ${PY4J_ZIP} | cut -d ' ' -f 1)
+echo "Found PY4J_ZIP: '${PY4J_ZIP}'" >&2
+
+if (( "${SPARK_MAJOR_VERSION}" >= 2 )); then
+  PACKAGES_ARG=''
+else
+  PACKAGES_ARG='--packages com.databricks:spark-csv_2.10:1.3.0'
+fi
+
+cat << EOF
+{
+ "argv": [
+    "python", "-m", "ipykernel", "-f", "{connection_file}"],
+ "display_name": "PySpark",
+ "language": "python",
+ "env": {
+    "SPARK_HOME": "/usr/lib/spark/",
+    "PYTHONPATH": "/usr/lib/spark/python/:${PY4J_ZIP}",
+    "PYTHONSTARTUP": "/usr/lib/spark/python/pyspark/shell.py",
+    "PYSPARK_SUBMIT_ARGS": "--master yarn --deploy-mode client ${PACKAGES_ARG} pyspark-shell"
+ }
+}
+EOF

--- a/initialization-actions/jupyter/launch-jupyter-interface.sh
+++ b/initialization-actions/jupyter/launch-jupyter-interface.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -e
+
+DIR="${BASH_SOURCE%/*}"
+[[ ! -d "$DIR" ]] && DIR="$PWD"
+
+source "$DIR/../util/utils.sh"
+
+function usage {
+    echo "Creates an SSH tunnel and socks proxy and launches Chrome, using the environment "
+    echo "variable DATAPROC_CLUSTER_NAME for the unique cluster name. The cluster metadata "
+    echo "must contain a value for the key 'JUPYTER_PORT'."
+    echo ""
+    echo "If the appropriate environment variables are not set and the appropriate command"
+    echo "line arguments are not given, then the usage message will be displayed and the "
+    echo "script will exit."
+    echo ""
+    echo "usage: $0 [-h] [-c=cluster-name] [-z=zone]"
+    echo "    -h                 display help"
+    echo "    -z=zone            specify cloud zone for cluster"
+    echo "    -c=cluster-name    specify unique dataproc cluster name to launch"
+    exit 1
+}
+
+for i in "$@"
+do
+    case $i in
+        -z=*)
+            ZONE="${i#*=}"
+            shift # past argument=value
+            ;;
+        -c=*)
+            DATAPROC_CLUSTER_NAME="${i#*=}"
+            shift # past argument=value
+            ;;
+        -h)
+            usage
+            ;;
+        *)
+            ;;
+    esac
+done
+
+[[ -z $DATAPROC_CLUSTER_NAME ]] && usage
+[[ -z $ZONE ]] && usage
+JUPYTER_PORT=$(get_metadata_property $DATAPROC_CLUSTER_NAME JUPYTER_PORT)
+[[ ! $JUPYTER_PORT =~ ^[0-9]+$ ]] && throw "metadata must contain a valid 'JUPYTER_PORT' value, but instead has the value \"$JUPYTER_PORT\""
+
+# TODO: Ensure that Jupyter notebook is running on cluster master node
+
+echo "Using following cluster name: $DATAPROC_CLUSTER_NAME"
+echo "Using following cluster zone: $ZONE"
+echo "Using following remote dataproc jupyter port: $JUPYTER_PORT"
+echo ""
+
+# 0. Set default path to Chrome application (by operating system type).
+# OS X
+CHROME_APP_PATH="/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome"
+# Linux
+#CHROME_APP_PATH="/usr/bin/google-chrome"
+# Windows
+#CHROME_APP_PATH="C:\Program Files (x86)\Google\Chrome\Application\chrome.exe"
+
+# Following configuration at:
+# https://cloud.google.com/dataproc/cluster-web-interfaces
+# 1. Setup ssh tunnel and socks proxy
+ZONE_FLAG=""
+[[ -v ZONE ]] && ZONE_FLAG="--zone=$ZONE"
+gcloud compute ssh $ZONE_FLAG --ssh-flag="-D 10000" --ssh-flag="-N" --ssh-flag="-n" "$DATAPROC_CLUSTER_NAME-m" &
+sleep 5 # Wait for tunnel to be ready before opening browser...
+
+# 2.Launch Chrome instance, referencing the proxy server.
+# TODO: Parameterize the chrome app path
+# eval $CHROME_APP_PATH \
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome \
+    "http://$DATAPROC_CLUSTER_NAME-m:$JUPYTER_PORT" \
+    --proxy-server="socks5://localhost:10000" \
+    --host-resolver-rules="MAP * 0.0.0.0 , EXCLUDE localhost" \
+    --user-data-dir=/tmp/
+

--- a/initialization-actions/kafka/README.MD
+++ b/initialization-actions/kafka/README.MD
@@ -1,0 +1,24 @@
+# Kafka 
+
+This initialization action installs [Kafka](http://kafka.apache.org) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. To install Kafka you must first install ZooKeeper. In the future Cloud Dataproc clusters may include ZooKeeper by default but in the meantime you can use the ZooKeeper initialization action in [this GitHub repository](https://github.com/GoogleCloudPlatform/dataproc-initialization-actions).
+
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Kafka installed by:
+
+1. Uploading a copy of this initialization action (`kafka.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you may need to increase the `initialization-action-timeout` if this script takes a long time to run. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/kafka.sh   
+    --initialization-action-timeout 5m
+    ```
+1. Once the cluster has been created Kafka should be running on all worker nodes in the cluster. Kafka will use the three ZooKeeper nodes setup in `zookeeper.sh`.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script will install Kafka on all **worker nodes** by default (but not the master)
+* This script assumes you have run the `zookeeper.sh` script to instal ZooKeeper on the master and two (required) worker nodes
+* The `delete.topic.enable` property has been set to `true` by default so topics can be deleted

--- a/initialization-actions/kafka/kafka.sh
+++ b/initialization-actions/kafka/kafka.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#    Copyright 2015 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+set -x -e
+
+
+# Only run this on worker nodes
+if [[ $(/usr/share/google/get_metadata_value attributes/dataproc-role) == 'Master' ]]; then
+	exit 0
+fi
+
+# Variables for this script
+SCALA_VERSION="2.11"
+KAFKA_VERSION="0.9.0.0"
+CLUSTER_NAME=$(hostname | sed 's/\(.*\)-[m|w]-[0-9]*.*/\1/g')
+BROKER_ID=$(hostname | sed 's/.*-w-\([0-9]\)*.*/\1/g')
+DNS_NAME=$(dnsdomainname)
+
+# Download and extract Kafka
+cd ~
+wget http://www.us.apache.org/dist/kafka/${KAFKA_VERSION}/kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
+tar zxvf kafka_${SCALA_VERSION}-${KAFKA_VERSION}.tgz
+
+# Configure Kafka
+ZOOKEEPER_INSTANCES=
+for h in "m" "w-0" "w-1"; do
+	ZOOKEEPER_INSTANCES+=${CLUSTER_NAME}-$h.${DNS_NAME}:2181,
+done
+sed -i 's|^\(zookeeper\.connect=\).*|\1'${ZOOKEEPER_INSTANCES}'|' kafka_${SCALA_VERSION}-${KAFKA_VERSION}/config/server.properties
+sed -i 's,^\(broker\.id=\).*,\1'${BROKER_ID}',' kafka_${SCALA_VERSION}-${KAFKA_VERSION}/config/server.properties
+echo 'delete.topic.enable = true' >> kafka_${SCALA_VERSION}-${KAFKA_VERSION}/config/server.properties
+
+# Start Kafka
+nohup kafka_${SCALA_VERSION}-${KAFKA_VERSION}/bin/kafka-server-start.sh kafka_${SCALA_VERSION}-${KAFKA_VERSION}/config/server.properties > /var/log/kafka.log 2>&1 &

--- a/initialization-actions/list-consistency-cache/shared-list-consistency-cache.sh
+++ b/initialization-actions/list-consistency-cache/shared-list-consistency-cache.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Initialization action for reconfiguring Dataproc clusters to use a separate
+# NFS server for its GCS list-consistency cache, if the shared NFS server has
+# been configured appropriately. Any bdutil or Dataproc deployed master node
+# co-located in the same zone as the new Dataproc cluster is suitable for
+# serving as a shared list-consistency cache server.
+
+# Replace this with the GCE hostname of whatever suitable NFS master you wish
+# to share with your new Dataproc cluster.
+SHARED_NFS_MASTER='shared-nfs-cache'
+
+# Replace the autofs config's NFS-cache mount point to use the shared master.
+CUR_MASTER=$(/usr/share/google/get_metadata_value attributes/dataproc-master)
+sed -i "s/${CUR_MASTER}/${SHARED_NFS_MASTER}/g" \
+    /etc/auto.hadoop_gcs_metadata_cache
+
+# Restart autofs for it to pick up the new config.
+service autofs restart
+
+# Prime the directory to make autofs mount it.
+ls -l /hadoop_gcs_connector_metadata_cache
+
+# Now check that the 'mount' command finds the right mount point with the right
+# remote shared master.
+AUTOFS_MOUNTED_MASTER=$(mount | \
+    grep "/hadoop_gcs_connector_metadata_cache type nfs4" | \
+    cut -d ':' -f 1)
+if [[ ${AUTOFS_MOUNTED_MASTER} != ${SHARED_NFS_MASTER} ]]; then
+  echo "Autofs mounted ${AUTOFS_MOUNTED_MASTER} != ${SHARED_NFS_MASTER}!"
+  echo "Mount:"
+  mount
+  exit 1
+fi
+
+# Clean up NFS cacheserving on the master node.
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+if [[ "${ROLE}" == 'Master' ]]; then
+  # Remove the crontab for cleaning GCS cache.
+  rm -f /etc/cron.d/clean-gcs-caches
+
+  # Remove fstab entry for mounting the export directory.
+  sed -i "s/\(.*gcs_connector_metadata_cache.*\)/\#\1/" /etc/fstab
+
+  # Remove /etc/exports entry.
+  sed -i "s/\(.*gcs_connector_metadata_cache.*\)/\#\1/" /etc/exports
+
+  # Restart the nfs-kernel-server.
+  service nfs-kernel-server restart
+
+  # Unmount the export point and delete it.
+  umount /export/hadoop_gcs_connector_metadata_cache/
+  rm -rf /export/hadoop_gcs_connector_metadata_cache/
+fi

--- a/initialization-actions/oozie/README.MD
+++ b/initialization-actions/oozie/README.MD
@@ -1,0 +1,45 @@
+# Oozie 
+
+This initialization action installs the [Oozie](http://oozie.apache.org) workflow scheduler on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. The Oozie server, client, and web interface are installed. 
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Oozie installed by:
+
+1. Uploading a copy of this initialization action (`oozie.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+2. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER-NAME>`, specify the initialization action stored in `<GCS-BUCKET>`:
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER-NAME> \
+    --initialization-actions gs://<GCS-BUCKET>/oozie.sh
+    ```
+3. Once the cluster has been created Oozie should be running on the master node. 
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Testing Oozie
+You can test this Oozie installation by running the `oozie-examples` included with Oozie. The examples are in an archive at `/usr/share/doc/oozie/oozie-examples.tar.gz`. To run the MapReduce example, you can do the following:
+
+1. Move the examples to your home directory:<br/>
+`cp /usr/share/doc/oozie/oozie-examples.tar.gz ~`
+2. Decompress the archive:<br/>
+`tar -zxvf oozie-examples.tar.gz`
+3. Edit the MapReduce example with details for your cluster:<br/>
+`nameNode=hdfs://<cluster-name-m>:8020`<br/>
+`jobTracker=<cluster-name-m>:8032`
+4. Move the Oozie examples to HDFS:<br/>
+`hadoop fs -put ~/examples/ /user/<username>/`
+5. Run the example on the command line with:<br/>
+`oozie job -oozie http://127.0.0.1:11000/oozie -config \
+~/examples/apps/map-reduce/job.properties -run`
+   
+
+## Oozie web interface
+The Oozie web interface is available on port `11000` on the master node of the cluster. For example, the Oozie web intarface would be available at the following address for a cluster named `my-dataproc-cluster`:
+
+    http://my-dataproc-cluster-m:11000/oozie
+    
+To connect to the web interface you will need to create an SSH tunnel and use a SOCKS proxy. Instructions on how to do this are available in the [cloud dataproc documentation](https://cloud.google.com/dataproc/cluster-web-interfaces).
+
+## Important notes
+* As Oozie is updated in BigTop the version of Oozie which is installed with this action will change.
+* HDFS is running on port `8020` and the (YARN) JobTracker is on port `8032` which may be useful information for some jobs.

--- a/initialization-actions/oozie/oozie.sh
+++ b/initialization-actions/oozie/oozie.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Initialization action for installing Apache Oozie on a Google Cloud
+# Dataproc cluster. This script will install and configure Oozie to run on the
+# master node of a Dataproc cluster. The version of Oozie which is installed
+# comes from the BigTop repository. 
+#
+# You can find more information about Oozie at http://oozie.apache.org/
+# For more information in init actions and Google Cloud Dataproc see the Cloud
+# Dataproc documentation at https://cloud.google.com/dataproc/init-actions
+#
+# This script should run in under a few minutes
+
+# Determine the role of this node
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+
+# Only run on the master node of the cluster
+if [[ "${ROLE}" == 'Master' ]]; then
+  # Upgrade the repository and install Oozie
+  apt-get update
+  apt-get install oozie oozie-client -y
+  
+  # The ext library is needed to enable the Oozie web console
+  wget http://archive.cloudera.com/gplextras/misc/ext-2.2.zip
+  unzip ext-2.2.zip
+  cp -ax ext-2.2 /usr/lib/oozie/libext/
+  
+  # Create the Oozie database
+  sudo -u oozie /usr/lib/oozie/bin/ooziedb.sh create -run
+  
+  # Hadoop must allow impersonation for Oozie to work properly
+  cat > core-site-patch.xml <<EOF
+  <property>
+    <name>hadoop.proxyuser.oozie.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.oozie.groups</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.${user.name}.hosts</name>
+    <value>*</value>
+  </property>
+  <property>
+    <name>hadoop.proxyuser.${user.name}.groups</name>
+	<value>*</value>
+  </property>
+EOF
+  sed -i '/<\/configuration>/e cat core-site-patch.xml' \
+	  /etc/hadoop/conf/core-site.xml
+  
+  # Clean up temporary fles
+  rm -rf ext-2.2 ext-2.2.zip core-site-patch.xml
+  
+  # HDFS and MapReduce must be cycled; restart to clean things up
+  reboot
+fi

--- a/initialization-actions/post-init/README.md
+++ b/initialization-actions/post-init/README.md
@@ -1,0 +1,84 @@
+# On-boot commands
+
+This initialization action can be used as either an initialization action or as a startup-script,
+with the latter enabling support for commands which need to be re-run on reboot. This
+initialization action adds polling for the cluster itself to be fully healthy before issuing
+a command, effectively allowing "post-initiailization" actions which can include further setup
+or submitting a job.
+
+## Using this initialization action
+
+For now, the script relies on polling the Dataproc API to determine an authoritative state
+of cluster health on startup, so requires the `--scopes cloud-platform` flag; do not use
+this initialization action if you are unwilling to grant your Dataproc clusters' service
+account with the `cloud-platform` scope.
+
+The initialization action is designed to log the output of your post-init command into
+`/var/log/master-post-init.log`; when debugging, if it doesn't behave as expected, SSH
+into the master node and view that logfile for more details. If it doesn't exist, then
+you can likely find additional details in the initialization-action or startup-script
+logs also in the `/var/log` directory.
+
+## Examples
+
+### Submit a single job with cluster and turn off cluster on completion
+
+Simply modify the `POST_INIT_COMMAND` to whatever actual job submission command you want to run:
+
+    export CLUSTER_NAME=${USER}-shortlived-cluster
+    export POST_INIT_COMMAND=" \
+        gcloud dataproc jobs submit hadoop \
+            --cluster ${CLUSTER_NAME} \
+            --jar file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar \
+            teragen 10000 /tmp/teragen; \
+        gcloud dataproc clusters delete -q ${CLUSTER_NAME}"
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --scopes cloud-platform \
+        --initialization-actions gs://dataproc-initialization-actions/post-init/master-post-init.sh \
+        --metadata post-init-command="${POST_INIT_COMMAND}"
+
+
+### Submit a single job with cluster and turn off cluster only if job succeeds
+
+If you replace the semicolon with "&&" before the `gcloud dataproc clusters delete` call, then
+the cluster will only be deleted if the job was successful:
+
+    export CLUSTER_NAME=${USER}-shortlived-cluster
+    export POST_INIT_COMMAND=" \
+        gcloud dataproc jobs submit hadoop \
+            --cluster ${CLUSTER_NAME} \
+            --jar file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar \
+            teragen 10000 /tmp/teragen && \
+        gcloud dataproc clusters delete -q ${CLUSTER_NAME}"
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --scopes cloud-platform \
+        --initialization-actions gs://dataproc-initialization-actions/post-init/master-post-init.sh \
+        --metadata post-init-command="${POST_INIT_COMMAND}"
+
+## Create a cluster which automatically resubmits a job on restart or job termination (e.g. for streaming processing)
+
+If you supply this init action as a GCE "startup-script" instead of as an init action, then it
+will be run on every (re)boot. This can be leveraged to set up reliable "long-lived" jobs.
+
+Note that individual job incarnations will always be vulnerable to at least some failure mode
+by nature (master might suffer unexpected hardware reboot, AppMaster might crash, etc). So,
+a "long-lived" job generally won't be a single job incarnation, but rather just ongoing
+"resubmission" of a job with the same params on failure. Your application layer is then
+responsible for recovering any ongoing state, if applicable.
+
+Dataproc by default will forcibly terminate the YARN applications it detects which appear
+to be orphaned from a failed job driver/client program; this makes it safe to resubmit
+the job on reboot without manually tracking down orphaned YARN applications which may be
+consuming resources for the job that you want to resubmit.
+
+    export CLUSTER_NAME=${USER}-longrunning-job-cluster
+    export POST_INIT_COMMAND=" \
+        while true; do \
+          gcloud dataproc jobs submit spark \
+              --cluster ${CLUSTER_NAME} \
+              --jar gs://${BUCKET}/my-longlived-job.jar foo args; \
+        done"
+    gcloud dataproc clusters create ${CLUSTER_NAME} \
+        --scopes cloud-platform \
+        --metadata startup-script-url=gs://dataproc-initialization-actions/post-init/master-post-init.sh,post-init-command="${POST_INIT_COMMAND}"
+

--- a/initialization-actions/post-init/master-post-init.sh
+++ b/initialization-actions/post-init/master-post-init.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Can be used either under --metadata startup-script-url=... or with
+# --initialization-actions to invoke commands (like submitting a job)
+# after cluster becomes initially healthy and then on every master
+# reboot or a single time on cluster deployment, respectively.
+#
+# Examples:
+#   Submit a single job with cluster and turn off cluster on completion:
+#
+#     gcloud dataproc clusters create ${CLUSTER_NAME} --scopes cloud-platform --initialization-actions gs://${BUCKET}/master-post-init.sh --metadata post-init-command="gcloud dataproc jobs submit hadoop --cluster ${CLUSTER_NAME} --jar file:///usr/lib/hadoop-mapreduce/hadoop-mapreduce-examples.jar teragen 10000 /tmp/teragen; gcloud dataproc clusters delete -q ${CLUSTER_NAME}"
+#
+#   Create a cluster which runs a "forever-running" job, resubmitting on reboot
+#   or if the job terminates for any reason:
+#
+#     gcloud dataproc clusters create ${CLUSTER_NAME} --scopes cloud-platform --metadata startup-script-url=gs://${BUCKET}/master-post-init.sh,post-init-command="while true; do gcloud dataproc jobs submit spark --cluster ${CLUSTER_NAME} --jar gs://${BUCKET}/my-longlived-job.jar foo args; done"
+
+METADATA_ROOT='http://metadata/computeMetadata/v1/instance/attributes'
+
+# Only run on master. If you want to run on all nodes instead, then simply
+# remove these lines which exit for non-master nodes.
+ROLE=$(curl -f -s -H Metadata-Flavor:Google ${METADATA_ROOT}/dataproc-role)
+if [[ "${ROLE}" != 'Master' ]]; then
+  exit 0
+fi
+
+CLUSTER_NAME=$(curl -f -s -H Metadata-Flavor:Google \
+    ${METADATA_ROOT}/dataproc-cluster-name)
+
+# Fetch the actual command we want to run once the cluster is healthy.
+# The command is specified with the 'post-init-command' key.
+POST_INIT_COMMAND=$(curl -f -s -H Metadata-Flavor:Google \
+    ${METADATA_ROOT}/post-init-command)
+
+if [ -z ${POST_INIT_COMMAND} ]; then
+  echo "Failed to find metadata key 'post-init-command'"
+  exit 1
+fi
+
+# We must put the bulk of the login in a separate helper script so that we can
+# 'nohup' it.
+cat << EOF > /usr/local/bin/await_cluster_and_run_command.sh
+#!/bin/bash
+
+# Helper to get current cluster state.
+function get_cluster_state() {
+  echo \$(gcloud dataproc clusters describe ${CLUSTER_NAME} | \
+      grep -A 1 "^status:" | grep "state:" | cut -d ':' -f 2)
+}
+
+# Helper which waits for RUNNING state before issuing the command.
+function await_and_submit() {
+  local cluster_state=\$(get_cluster_state)
+  echo "Current cluster state: \${cluster_state}"
+  while [[ "\${cluster_state}" != 'RUNNING' ]]; do
+    echo "Sleeping to await cluster health..."
+    sleep 5
+    local cluster_state=\$(get_cluster_state)
+    if [[ "\${cluster_state}" == 'ERROR' ]]; then
+      echo "Giving up due to cluster state '\${cluster_state}'"
+      exit 1
+    fi
+  done
+
+  ${POST_INIT_COMMAND}
+}
+
+await_and_submit
+EOF
+
+chmod 750 /usr/local/bin/await_cluster_and_run_command.sh
+
+# Uncomment this following line and comment out the line after it to throw away
+# the stdout/stderr of the command instead of logging it.
+#nohup /usr/local/bin/await_cluster_and_run_command.sh &>> /dev/null &
+nohup /usr/local/bin/await_cluster_and_run_command.sh &>> \
+    /var/log/master-post-init.log &

--- a/initialization-actions/presto/README.MD
+++ b/initialization-actions/presto/README.MD
@@ -1,0 +1,24 @@
+# Presto 
+
+This initialization action installs the latest version of [Presto](prestodb.io) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. Additionally, this script will configure Presto to work with Hive on the cluster. The master Cloud Dataproc node will be the coordinator and all Cloud Dataproc workers will be Presto workers.
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Presto installed by:
+
+1. Uploading a copy of this initialization action (`presto.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you may need to increase the `initialization-action-timeout` if this script takes a long time to run. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 5 minutes.
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/presto.sh   
+    --initialization-action-timeout 5m
+    ```
+1. Once the cluster has been created, Presto is configured to run on port `8080` (though you can change this int he script) on the master node in a Cloud Dataproc cluster. To connect to the Presto web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation. You can also use the [Presto command line interface](https://prestodb.io/docs/current/installation/cli.html) using the `presto` command on the master node.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script must be updated based on which Presto version you wish you install
+* You may need to adjust the memory settings in `jvm.config` based on your needs
+* Presto is set to use HTTP port `8080` by default
+* Only the Hive connector is configured by default

--- a/initialization-actions/presto/presto.sh
+++ b/initialization-actions/presto/presto.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#    Copyright 2015 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+set -x -e
+
+# Variables for running this script
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+HOSTNAME=$(hostname)
+DNSNAME=$(dnsdomainname)
+FQDN=${HOSTNAME}.$DNSNAME
+CONNECTOR_JAR=$(find /usr/lib/hadoop/lib -name 'gcs-connector-*.jar')
+PRESTO_VERSION="0.144.1"
+HTTP_PORT="8080"
+
+# Download and unpack Presto server
+wget https://repo1.maven.org/maven2/com/facebook/presto/presto-server/${PRESTO_VERSION}/presto-server-${PRESTO_VERSION}.tar.gz
+tar -zxvf presto-server-${PRESTO_VERSION}.tar.gz
+mkdir /var/presto
+mkdir /var/presto/data
+
+# Copy required Jars
+cp ${CONNECTOR_JAR} presto-server-${PRESTO_VERSION}/plugin/hive-hadoop2
+
+# Configure Presto
+mkdir presto-server-${PRESTO_VERSION}/etc
+mkdir presto-server-${PRESTO_VERSION}/etc/catalog
+
+cat > presto-server-${PRESTO_VERSION}/etc/node.properties <<EOF
+node.environment=production
+node.id=$(uuidgen)
+node.data-dir=/var/presto/data
+EOF
+
+# TODO - Inspect /etc/hive/conf/hite-site.xml to pull this uri
+cat > presto-server-${PRESTO_VERSION}/etc/catalog/hive.properties <<EOF
+connector.name=hive-hadoop2
+hive.metastore.uri=thrift://localhost:9083
+EOF
+
+# Compute memory settings based on Spark's settings.
+# We use "tail -n 1" since overrides are applied just by order of appearance.
+SPARK_EXECUTOR_MB=$(grep spark.executor.memory /etc/spark/conf/spark-defaults.conf | tail -n 1 | cut -d '=' -f 2 | cut -d 'm' -f 1)
+SPARK_EXECUTOR_CORES=$(grep spark.executor.cores /etc/spark/conf/spark-defaults.conf | tail -n 1 | cut -d '=' -f 2)
+SPARK_EXECUTOR_OVERHEAD_MB=$(grep spark.yarn.executor.memoryOverhead /etc/spark/conf/spark-defaults.conf | tail -n 1 | cut -d '=' -f 2)
+SPARK_EXECUTOR_COUNT=$(( $(nproc) / ${SPARK_EXECUTOR_CORES} ))
+
+# Add up overhead and allocated executor MB for container size.
+SPARK_CONTAINER_MB=$(( ${SPARK_EXECUTOR_MB} + ${SPARK_EXECUTOR_OVERHEAD_MB} ))
+PRESTO_JVM_MB=$(( ${SPARK_CONTAINER_MB} * ${SPARK_EXECUTOR_COUNT} ))
+
+# Give query.max-memorr-per-node 60% of Xmx; this more-or-less assumes a
+# single-tenant use case rather than trying to allow many concurrent queries
+# against a shared cluster.
+# Subtract out SPARK_EXECUTOR_OVERHEAD_MB in both the query MB and reserved
+# system MB as a crude approximation of other unaccounted overhead that we need
+# to leave betweenused bytes and Xmx bytes. Rounding down by integer division
+# here also effectively places round-down bytes in the "general" pool.
+PRESTO_QUERY_NODE_MB=$(( ${PRESTO_JVM_MB} * 6 / 10 - ${SPARK_EXECUTOR_OVERHEAD_MB} ))
+PRESTO_RESERVED_SYSTEM_MB=$(( ${PRESTO_JVM_MB} * 4 / 10 - ${SPARK_EXECUTOR_OVERHEAD_MB} ))
+
+cat > presto-server-${PRESTO_VERSION}/etc/jvm.config <<EOF
+-server
+-Xmx${PRESTO_JVM_MB}m
+-Xmn512m
+-XX:+UseConcMarkSweepGC
+-XX:+ExplicitGCInvokesConcurrent
+-XX:ReservedCodeCacheSize=150M
+-XX:+ExplicitGCInvokesConcurrent
+-XX:+CMSClassUnloadingEnabled
+-XX:+AggressiveOpts
+-XX:+HeapDumpOnOutOfMemoryError
+-XX:OnOutOfMemoryError=kill -9 %p
+-Dhive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
+-Djava.library.path=/usr/lib/hadoop/lib/native/:/usr/lib/
+EOF
+
+if [[ "${ROLE}" == 'Master' ]]; then
+	# Configure master properties
+	PRESTO_MASTER_FQDN=${FQDN}
+	cat > presto-server-${PRESTO_VERSION}/etc/config.properties <<EOF
+coordinator=true
+node-scheduler.include-coordinator=false
+http-server.http.port=${HTTP_PORT}
+query.max-memory=999TB
+query.max-memory-per-node=${PRESTO_QUERY_NODE_MB}MB
+resources.reserved-system-memory=${PRESTO_RESERVED_SYSTEM_MB}MB
+discovery-server.enabled=true
+discovery.uri=http://${PRESTO_MASTER_FQDN}:${HTTP_PORT}
+EOF
+
+	# Install cli
+	$(wget https://repo1.maven.org/maven2/com/facebook/presto/presto-cli/${PRESTO_VERSION}/presto-cli-${PRESTO_VERSION}-executable.jar -O /usr/bin/presto)
+	$(chmod a+x /usr/bin/presto)
+else
+	MASTER_NODE_NAME=$(hostname | sed 's/\(.*\)-s\?w-[a-z0-9]*.*/\1/g')
+	PRESTO_MASTER_FQDN=${MASTER_NODE_NAME}-m.${DNSNAME}
+	cat > presto-server-${PRESTO_VERSION}/etc/config.properties <<EOF
+coordinator=false
+http-server.http.port=${HTTP_PORT}
+query.max-memory=999TB
+query.max-memory-per-node=${PRESTO_QUERY_NODE_MB}MB
+resources.reserved-system-memory=${PRESTO_RESERVED_SYSTEM_MB}MB
+discovery.uri=http://${PRESTO_MASTER_FQDN}:${HTTP_PORT}
+EOF
+fi
+
+# Start presto
+presto-server-${PRESTO_VERSION}/bin/launcher start

--- a/initialization-actions/stackdriver/README.md
+++ b/initialization-actions/stackdriver/README.md
@@ -1,0 +1,54 @@
+# Stackdriver Initialization Action
+
+This initialization action downloads and installs the [Google Stackdriver](https://cloud.google.com/stackdriver/)
+installations script. This will for monitoring a Cloud Dataproc cluster within Stackdriver. With this monitoring
+you can, for example, look at fine-grained resource use across the cluster, alarm on various triggers, or
+analyze the performance of your cluster.
+
+## Using this initialization action
+
+**You need to configure Stackdriver before you use this initialization action.** Specifically, you must create a group
+based on the cluster name prefix of your cluster. Once you do, Stackdriver will detect any new instances created
+with that prefix and use this group as the basis for your alerting policies and dashboards. You can create a new
+group through the [Stackdriver user interface](https://app.google.stackdriver.com/groups/create).
+
+Once you have configured a copy of this script, you can use this initialization action to create a new Dataproc cluster
+with the Stackdriver agent installed by:
+
+1. Uploading a copy of the initialization action (`stackdriver.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. You must add the [requisite stackdriver monitoring scope(s)](https://cloud.google.com/monitoring/api/authentication#cloud_monitoring_scopes). The following command will create a new cluster named `<CLUSTER_NAME>` and specify the initialization action stored in `<GCS_BUCKET>`.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh \
+        --scopes https://www.googleapis.com/auth/monitoring.write
+    ```
+1. Once the cluster is online, Stackdriver should automatically start capturing data from your cluster. You can visit
+the [Stackdriver interface](https://app.google.stackdriver.com/) to view the metrics.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Useful Tips
+
+To better identify your cluster in a Stackdriver dashboard, you'll likely want to append a unique tag when creating
+your cluster:
+
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+        --initialization-actions gs://<GCS_BUCKET>/stackdriver.sh \
+        --scopes https://www.googleapis.com/auth/monitoring.write \
+        --tags my-dataproc-cluster-20160901-1518
+
+This way, even if you reuse your `<CLUSTER_NAME>` in the future, you can easily disambiguate which incarnation
+of the cluster you want to look at in your Stackdriver dashboards. For convenience, you may also want to use
+to Google-hosted copy of the dataproc-initialization-actions repo; for example, once you've enabled the Stackdriver
+APIs you can simply copy/paste:
+
+    gcloud dataproc clusters create ${USER}-dataproc-cluster \
+        --initialization-actions gs://dataproc-initialization-actions/stackdriver/stackdriver.sh \
+        --scopes https://www.googleapis.com/auth/monitoring.write \
+        --tags ${USER}-dataproc-cluster-$(date +%Y%m%d-%H%M%S)
+
+## Important notes
+* If you do not create a group in Stackdriver with the same prefix as your cluster name or using the unique tag you
+provided at cluster-creation time, Stackdriver will not automatically pick up data from your cluster.
+* Ensure you have reviewed the [pricing for Stackdriver](https://cloudplatform.googleblog.com/2016/06/announcing-pricing-for-Google-Stackdriver.html)

--- a/initialization-actions/stackdriver/stackdriver.sh
+++ b/initialization-actions/stackdriver/stackdriver.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS-IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script installs the Stackdriver agent on your Cloud Dataproc
+# cluster so you can monitor your cluster with Stackdriver.
+#
+# Once you create a cluster with this initialization action, you will
+# need to perform some configuration in Stackdriver. Specifically, you must
+# create a group based on the cluster name prefix. This will detect any new
+# instances created with that prefix and use this group as the basis for
+# your alerting policies and dashboards
+
+# Download and run the Stackdriver installation script
+curl -O "https://repo.stackdriver.com/stack-install.sh"
+sudo bash stack-install.sh --write-gcm

--- a/initialization-actions/tez/README.MD
+++ b/initialization-actions/tez/README.MD
@@ -1,0 +1,28 @@
+# Apache Tez
+
+This initialization action installs the latest version of [Apache Tez](https://tez.apache.org/) on a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster. In this initialization action:
+
+1. Required libraries such as [`protobuf`](https://github.com/google/protobuf) are installed
+2. Tez is compiled
+3. Tez is put into HDFS
+4. Hadoop is configured to work with Tez on the Dataproc cluster
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Apache Tez installed by:
+
+1. Uploading a copy of this initialization action (`tez.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you will need to increase the `initialization-action-timeout` to at least 15 minutes to allow for Tez and its dependencies to compile and install. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`, and increase the timeout to 15 minutes.
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/tez.sh   
+    --initialization-action-timeout 15m
+    ```
+1. Once the cluster is created, Tez should work with your Cloud Dataproc jobs.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script has a number of user-defined variables at the top, such as the Tez version and install location.
+* This script builds from source which may cause issues if you use an unstable release.
+* Be careful with the [`protobuf`](https://github.com/google/protobuf) version - Tez often requires a *very specific* version to function properly.

--- a/initialization-actions/tez/tez.sh
+++ b/initialization-actions/tez/tez.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#  Copyright 2015 Google, Inc.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+set -x -e
+
+#  Define important variables
+tez_version="0.7.0"
+protobuf_version="2.5.0"
+tez_hdfs_path="/apps/tez"
+tez_jars="/usr/lib/tez"
+tez_conf_dir="/etc/tez/conf"
+role="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+
+if [[ "${role}" == 'Master' ]]; then
+  #  Install Tez
+  apt-get install tez -y
+  
+  #  Stage Tez
+  hadoop fs -mkdir -p ${tez_hdfs_path}
+  hadoop fs -copyFromLocal ${tez_jars}/* ${tez_hdfs_path}/
+
+  #  Update the hadoop-env.sh
+  {
+    echo "export TEZ_CONF_DIR=/etc/tez/"
+    echo "export tez_jars=${tez_jars}"
+    echo "HADOOP_CLASSPATH=\$HADOOP_CLASSPATH:${tez_conf_dir}:${tez_jars}/*:${tez_jars}/lib/*"
+  } >> /etc/hadoop/conf/hadoop-env.sh
+fi
+
+set +x +e

--- a/initialization-actions/user-environment/README.MD
+++ b/initialization-actions/user-environment/README.MD
@@ -1,0 +1,15 @@
+# Customize environment
+
+This initialization action customizes the environment of all current and future non-system users on the VM. If you wish to ssh into your cluster a lot and prefer to customize the user environment, this script provides a starting point reference.
+
+By default it only enables the options already present in the .bashrc that Debian provides, but it documents where further changes can be made and gives some commented out examples.
+
+## Using this initialization action
+You can use this initialization action by:
+
+1. Uploading a copy of this initialization action (`user-environment.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`:
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/user-environment

--- a/initialization-actions/user-environment/user-environment.sh
+++ b/initialization-actions/user-environment/user-environment.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Copyright 2015 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o xtrace
+
+## Only install customize master node by default.
+## Delete to customize all nodes.
+[[ "${HOSTNAME}" =~ -m$ ]] || exit
+
+## Make global changes here
+apt-get update || true
+apt-get install -y vim
+update-alternatives --set editor /usr/bin/vim.basic
+#apt-get install -y tmux sl
+
+## The following script will get run as each user in their home directory.
+cat << 'EOF' > /tmp/customize_home_dir.sh
+set -o errexit
+set -o nounset
+set -o xtrace
+
+## Uncomment all options in Debian's .bashrc
+## Includes a forced color prompt, ls aliases, misc.
+sed -Ei 's/#(\S)/\1/' ${HOME}/.bashrc
+
+## Optionally customize .bashrc further
+cat << 'EOT' >> ${HOME}/.bashrc
+## Useful aliases
+#alias rm='rm -i'
+#alias cp='cp -i'
+#alias mv='mv -i'
+#alias sl='sl -e'
+#alias LS='LS -e'
+
+## Add ISO 8601 formatted date time to prompt.
+#PS1="\[\033[01;34m\][\D{%FT%T}]\[\033[00m\] ${PS1}"
+EOT
+
+## Make any other changes here.
+## e.g. use the system provided .vimrc
+#cp /usr/share/vim/vimrc ${HOME}/.vimrc
+## Uncomment optional settings
+#sed -Ei 's/^"(\S|  )/\1/' ${HOME}/.vimrc
+## Except compatible, because no one wants that.
+#sed -i 's/set compatible/"&/' ${HOME}/.vimrc
+EOF
+
+## Use members of the group adm as the list of users worth customizing.
+USERS="$(getent group adm | sed -e 's/.*://' -e 's/,/ /g')"
+for user in ${USERS}; do
+  sudo -iu ${user} bash /tmp/customize_home_dir.sh
+done
+
+## Customize /etc/skel for future users.
+HOME=/etc/skel bash /tmp/customize_home_dir.sh

--- a/initialization-actions/util/utils.sh
+++ b/initialization-actions/util/utils.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+function_exists () {
+    declare -f -F $1 > /dev/null
+    return $?
+}
+
+throw () {
+    echo "$*" >&2
+    echo
+    function_exists usage && usage
+    exit 1
+}
+
+get_metadata_property () {
+    [[ -z $1 ]] && throw "missing function param for DATAPROC_CLUSTER_NAME" || DATAPROC_CLUSTER_NAME=$1
+    [[ -z $2 ]] && throw "missing function param for METADATA_KEY" || METADATA_KEY=$2
+    # Get $DATAPROC_CLUSTER_NAME metadata value for key $METADATA_KEY...
+    gcloud dataproc clusters describe $DATAPROC_CLUSTER_NAME | python -c "import sys,yaml; cluster = yaml.load(sys.stdin); print(cluster['config']['gceClusterConfig']['metadata']['$METADATA_KEY'])"
+}
+

--- a/initialization-actions/zeppelin/README.MD
+++ b/initialization-actions/zeppelin/README.MD
@@ -1,0 +1,27 @@
+# Apache Zeppelin
+
+This initialization action installs the latest version of [Apache Zeppelin](https://zeppelin.apache.org/) on a master node within a [Google Cloud Dataproc](https://cloud.google.com/dataproc) cluster.
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with Apache Zeppelin installed by:
+
+1. Uploading a copy of this initialization action (`zeppelin.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. The following command will create a new cluster named `<CLUSTER_NAME>`, specify the initialization action stored in `<GCS_BUCKET>`.
+
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/zeppelin.sh
+    ```
+1. Once the cluster has been created, Zeppelin is configured to run on port `8080` on the master node in a Dataproc cluster. To connect to the Apache Zeppelin web interface, you will need to create an SSH tunnel and use a SOCKS 5 Proxy as described in the [dataproc web interfaces](https://cloud.google.com/dataproc/cluster-web-interfaces) documentation.
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes & Known issues
+* The port Zeppelin runs on is configurable by passing `--metadata=zeppelin-port=<PORT>' to `gcloud`.
+* This installs Zeppelin 0.5.6 in Dataproc 1.0 and Zeppelin 0.6.1 in Dataproc 1.1.
+* It configures the BigQuery interpreter in 0.6.1.
+* It makes no attempt to install or configure matplotlib, because it [requires an XServer](https://github.com/apache/zeppelin/blob/master/docs/interpreter/python.md#matplotlib-integration).
+* By default it only install Rs graphing libraries that ship with Debian 8 (ggplot2, knitr, and googlevis).
+  * To install the other required R libraries (mplot and rCharts), uncomment lines after "Uncomment here" in zeppelin.sh.
+  * There are still some issues with examples in the R Tutorial (under investation).
+* The Hive interpreter in missing in Dataproc 1.1 (under investigation).

--- a/initialization-actions/zeppelin/zeppelin.sh
+++ b/initialization-actions/zeppelin/zeppelin.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# Copyright 2015 Google, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This init script installs Apache Zeppelin on the master node of a Cloud
+# Dataproc cluster. Zeppelin is also configured based on the size of your
+# cluster and the versions of Spark/Hadoop which are installed.
+
+set -x -e
+
+# Only run on the master node
+ROLE="$(/usr/share/google/get_metadata_value attributes/dataproc-role)"
+INTERPRETER_FILE='/etc/zeppelin/conf/interpreter.json'
+ZEPPELIN_PORT="$(/usr/share/google/get_metadata_value attributes/zeppelin-port || true)"
+
+if [[ "${ROLE}" == 'Master' ]]; then
+  # Install zeppelin. Don't mind if it fails to start the first time.
+  apt-get install -y zeppelin || dpkg -l zeppelin
+
+  for i in {1..6}; do
+    if [[ -r "${INTERPRETER_FILE}" ]]; then
+      break
+    else
+      sleep 10
+    fi
+  done
+  # Ideally we would use Zeppelin's REST API, but it is difficult, especially
+  # between versions. So sed the JSON file.
+  service zeppelin stop
+  # Set spark.yarn.isPython to fix Zeppelin pyspark in Dataproc 1.0.
+  sed -i 's/\(\s*\)"spark\.app\.name[^,}]*/&,\n\1"spark.yarn.isPython": "true"/' \
+      "${INTERPRETER_FILE}"
+
+  # Link in hive configuration.
+  ln -s /etc/hive/conf/hive-site.xml /etc/zeppelin/conf
+
+  if [[ -n "${ZEPPELIN_PORT}" ]]; then
+    echo "export ZEPPELIN_PORT=${ZEPPELIN_PORT}" \
+        >> /etc/zeppelin/conf/zeppelin-env.sh
+  fi
+
+  # Install R libraries and configure BigQuery for Zeppelin 0.6.1+
+  ZEPPELIN_VERSION=$(dpkg-query --showformat='${Version}' --show zeppelin)
+  if dpkg --compare-versions "${ZEPPELIN_VERSION}" '>=' 0.6.1; then
+    # Set BigQuery project ID if present.
+    PROJECT=$(/usr/share/google/get_metadata_value ../project/project-id)
+    sed -i "s/\(\"zeppelin.bigquery.project_id\"\)[^,}]*/\1: \"${PROJECT}\"/" \
+        "${INTERPRETER_FILE}"
+
+    # TODO(pmkc): Add googlevis to Zeppelin Package recommendations
+    apt-get install -y r-cran-googlevis
+
+## Uncomment here to compile and install 'mplot' and 'rCharts'.
+#    # Install compile dependencies
+#    apt-get install -y \
+#      r-cran-doparallel r-cran-httr r-cran-memoise r-cran-openssl \
+#      r-cran-rcurl r-cran-plyr r-cran-shiny r-cran-glmnet r-cran-data.table \
+#      libssl-dev libcurl4-openssl-dev
+#
+#    cat << EOF > install_script.r
+#options('Ncpus'=10, repos = 'http://cran.us.r-project.org')
+#install.packages('devtools')
+#require('devtools')
+## Install version 0.7.7 to avoid dependency on glmulti and RJava
+#install_version('mplot', version = '0.7.7', upgrade_dependencies = FALSE)
+#install_github('ramnathv/rCharts', upgrade_dependencies = FALSE)
+#update.packages('ggplot', ask = FALSE)
+#EOF
+#    R -f install_script.r
+  fi
+
+  # Restart Zeppelin
+  service zeppelin start
+fi

--- a/initialization-actions/zookeeper/README.MD
+++ b/initialization-actions/zookeeper/README.MD
@@ -1,0 +1,27 @@
+# ZooKeeper 
+
+Presently, [Google Cloud Dataproc](https://cloud.google.com) clusters do not have [ZooKeeper](http://zookeeper.apache.org) insalled. This may change in the future; in the interim, this initialization action installs ZooKeeper on a Cloud Dataproc cluster.
+
+Specifically, this script will (unless changed) install ZooKeeper on the **three required** nodes for a Cloud Dataproc Cluster:
+
+* Master node (`-m`)
+* Worker 1 (`-w-0`)
+* Worker 2 (`-w-1`)
+
+## Using this initialization action
+You can use this initialization action to create a new Dataproc cluster with ZooKeeper installed by:
+
+1. Uploading a copy of this initialization action (`zookeeper.sh`) to [Google Cloud Storage](https://cloud.google.com/storage).
+1. Using the `gcloud` command to create a new cluster with this initialization action. **Note** - you may need to increase the `initialization-action-timeout` if this script takes a long time to run. The following command will create a new cluster named `<CLUSTER_NAME>`, and specify the initialization action stored in `<GCS_BUCKET>`.
+   
+    ```bash
+    gcloud dataproc clusters create <CLUSTER_NAME> \
+    --initialization-actions gs://<GCS_BUCKET>/zookeeper.sh
+    ```
+    Since ZooKeeper installs quickly, it's unlikely you will need to increase the `initialization-action-timeout` unless you have a very large cluster or are running more than one initialization action.
+1. Once the cluster has been created, ZooKeeper is configured to run on port `2181` (though you can change this int he script.)
+
+You can find more information about using initialization actions with Dataproc in the [Dataproc documentation](https://cloud.google.com/dataproc/init-actions).
+
+## Important notes
+* This script does not optimize ZooKeeper and you may wish to further configure ZooKeeper based on the [official documentation](https://zookeeper.apache.org/doc/trunk/).

--- a/initialization-actions/zookeeper/zookeeper.sh
+++ b/initialization-actions/zookeeper/zookeeper.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#    Copyright 2015 Google, Inc.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+set -x -e
+
+# Variables for this script
+ROLE=$(/usr/share/google/get_metadata_value attributes/dataproc-role)
+CLUSTER_NAME=$(hostname | sed -r 's/(.*)-[w|m](-[0-9]+)?$/\1/')
+
+# Download and extract ZooKeeper
+apt-get install -y zookeeper
+mkdir -p /var/lib/zookeeper
+
+# Configure ZooKeeper node ID
+NODE_NUMBER=1
+if [[ "${ROLE}" == 'Worker' ]]; then
+	NODE_NUMBER=$((`hostname | sed 's/.*-w-\([0-9]\)*.*/\1/g'`+2))
+fi
+echo ${NODE_NUMBER} > /var/lib/zookeeper/myid
+
+# Write ZooKeeper configuration file
+cat > /etc/zookeeper/conf/zoo.cfg <<EOF
+tickTime=2000
+dataDir=/var/lib/zookeeper
+clientPort=2181
+initLimit=5
+syncLimit=2
+server.1=${CLUSTER_NAME}-m:2888:3888
+server.2=${CLUSTER_NAME}-w-0:2888:3888
+server.3=${CLUSTER_NAME}-w-1:2888:3888
+EOF
+
+# Start ZooKeeper
+ZOO_LOG_DIR=/var/log/zookeeper /usr/lib/zookeeper/bin/zkServer.sh start


### PR DESCRIPTION
**Clone init action repo**
Copy all init actions as of 3/27 to this repo as the first step in merging the two repos.

**PySpark example**
Moving the hello-world PySpark example from the Google Cloud docs
(https://cloud.google.com/dataproc/docs/guides/submit-job#submit_a_sampl
e_pyspark_job) to this repo. Right now when someone tries to run the sample, it will possibly fail for them (they are using Windows, for example.)