### PR TITLE
[custom-images] Additional files/directories uploaded along with customization script.

### DIFF
--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -78,9 +78,9 @@ python generate_custom_image.py \
     the access to all cloud platform services that is granted by IAM roles.
     Note: IAM role must allow the VM instance to access GCS bucket in order to
     access scripts and write logs.
-*   **--extra-sources**: Additional files/directories which will be uploaded along 
-    with customization script. Pass this argument as string which will evaluate to
-    a json dictionary. Read more about
+*   **--extra-sources**: Additional files/directories uploaded along with
+    customization script. This argument is evaluated to a json dictionary.
+    Read more about
     (sources in daisy)[https://googlecloudplatform.github.io/compute-image-tools/daisy-workflow-config-spec.html#sources] 
 *   **--disk-size**: The size in GB of the disk attached to the VM instance
     used to build custom image. The default is `10` GB.

--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -87,25 +87,25 @@ python generate_custom_image.py \
 
 ### Example
 
-Create a custom image with name `custom_image_1_2_3` with Dataproc version
+Create a custom image with name `custom-image-1-2-3` with Dataproc version
 `1.12.11`:
 ```shell
 python generate_custom_image.py \ --image-name
-custom_image_1_2_3 --dataproc-version 1.2.11 --customization-script
+custom-image-1-2-3 --dataproc-version 1.2.11 --customization-script
 ~/custom-script.sh --daisy-path ~/daisy --zone us-central1-f --gcs-bucket
 gs://my-test-bucket
 ```
 
 Create a custom image with name `custom_image` and disables smoke test:
 ```shell
-python generate_custom_image.py \ --image-name custom_image_1_2_3
+python generate_custom_image.py \ --image-name custom-image-1-2-3
 --dataproc-version 1.2.11 --customization-script ~/custom-script.sh --daisy-path
 ~/daisy --zone us-central1-f --gcs-bucket gs://my-test-bucket --no-smoke-test
 ```
 
 Create a custom image with name `custom_image` and upload extra sources to the image:
 ```shell
-python generate_custom_image.py \ --image-name custom_image_1_2_3
+python generate_custom_image.py \ --image-name custom-image-1-2-3
 --dataproc-version 1.2.11 --customization-script ~/custom-script.sh --daisy-path
 ~/daisy --zone us-central1-f --gcs-bucket gs://my-test-bucket --extra-sources "{\"requirements.txt\": \"/path/to/requirements.txt\"}"
 ```

--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -78,6 +78,12 @@ python generate_custom_image.py \
     the access to all cloud platform services that is granted by IAM roles.
     Note: IAM role must allow the VM instance to access GCS bucket in order to
     access scripts and write logs.
+*   **--extra-sources**: Additional files/directories which will be uploaded along 
+    with customization script. 
+    Pass this argument as string which will evaluate to a json dictionary.
+    Read more about (sources in daisy)[https://googlecloudplatform.github.io/compute-image-tools/daisy-workflow-config-spec.html#sources] 
+
+
 
 ### Example
 
@@ -95,4 +101,11 @@ Create a custom image with name `custom_image` and disables smoke test:
 python generate_custom_image.py \ --image-name custom_image_1_2_3
 --dataproc-version 1.2.11 --customization-script ~/custom-script.sh --daisy-path
 ~/daisy --zone us-central1-f --gcs-bucket gs://my-test-bucket --no-smoke-test
+```
+
+Create a custom image with name `custom_image` and upload extra sources to the image:
+```shell
+python generate_custom_image.py \ --image-name custom_image_1_2_3
+--dataproc-version 1.2.11 --customization-script ~/custom-script.sh --daisy-path
+~/daisy --zone us-central1-f --gcs-bucket gs://my-test-bucket --extra-sources "{\"requirements.txt\": \"/path/to/requirements.txt\"}"
 ```

--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -79,11 +79,9 @@ python generate_custom_image.py \
     Note: IAM role must allow the VM instance to access GCS bucket in order to
     access scripts and write logs.
 *   **--extra-sources**: Additional files/directories which will be uploaded along 
-    with customization script. 
-    Pass this argument as string which will evaluate to a json dictionary.
-    Read more about (sources in daisy)[https://googlecloudplatform.github.io/compute-image-tools/daisy-workflow-config-spec.html#sources] 
-
-
+    with customization script. Pass this argument as string which will evaluate to
+    a json dictionary. Read more about
+    (sources in daisy)[https://googlecloudplatform.github.io/compute-image-tools/daisy-workflow-config-spec.html#sources] 
 *   **--disk-size**: The size in GB of the disk attached to the VM instance
     used to build custom image. The default is `10` GB.
 

--- a/custom-images/constants.py
+++ b/custom-images/constants.py
@@ -41,8 +41,7 @@ daisy_wf = """\
     "Name": "{image_name}",
     "Project": "{project_id}",
     "Sources": {{
-        "run.sh": "{run_script}",
-        "init_actions.sh": "{install_script}"
+        {sources}
     }},
     "Zone": "{zone}",{oauth}
     "GCSPath": "{gcs_bucket}",

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -362,8 +362,8 @@ def run():
       Pass this argument as string which will evaluate to a json dictionary.
       Read more about sources in daisy https://googlecloudplatform.github.io/
       compute-image-tools/daisy-workflow-config-spec.html#sources
-      Example: 
-      
+      Example:
+      '--extra-sources "{\\"notes.txt\\": \\"/path/to/notes.txt\\"}"'
       """)
 
   args = parser.parse_args()

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -358,12 +358,11 @@ def run():
       required=False,
       default={},
       help=
-      """(Optional) Additional files/directories which will be uploaded along 
-      with customization script. 
-      Pass this argument as string which will evaluate to a json dictionary.
+      """(Optional) Additional files/directories uploaded along with
+      customization script. This argument is evaluated to a json dictionary.
       Read more about sources in daisy https://googlecloudplatform.github.io/
-      compute-image-tools/daisy-workflow-config-spec.html#sources
-      Example:
+      compute-image-tools/daisy-workflow-config-spec.html#sources.
+      For example:
       '--extra-sources "{\\"notes.txt\\": \\"/path/to/notes.txt\\"}"'
       """)
 parser.add_argument(

--- a/custom-images/run.sh
+++ b/custom-images/run.sh
@@ -15,8 +15,8 @@
 # get daisy-sources-path
 DAISY_SOURCES_PATH=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/daisy-sources-path" -H "Metadata-Flavor: Google")
 
-# copy down init actions script
-gsutil cp "${DAISY_SOURCES_PATH}/init_actions.sh" ./init_actions.sh
+# copy down all sources (along with init_actions.sh script)
+gsutil -m cp -r "${DAISY_SOURCES_PATH}/*" ./
 
 # run init actions
 bash ./init_actions.sh


### PR DESCRIPTION
Right now generate_custom_image.py script uploads only customization-script to the machine while creating a custom image for Dataproc. Sometimes it is convenient to upload more than one file like for example requirements.txt in order to install required Python packages.

I made an extension to the generate_custom_image.py which adds `--extra-sources` argument which drives the upload of arbitrary files and folders to the GCE instance while building the image.

Related to issue https://github.com/GoogleCloudPlatform/cloud-dataproc/issues/48