### PR TITLE
[Custom images] Allow users to specify disk size

### DIFF
--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -78,6 +78,8 @@ python generate_custom_image.py \
     the access to all cloud platform services that is granted by IAM roles.
     Note: IAM role must allow the VM instance to access GCS bucket in order to
     access scripts and write logs.
+*   **--disk-size**: The size in GB of the disk attached to the VM instance
+    used to build custom image. The default is `10` GB.
 
 ### Example
 

--- a/custom-images/constants.py
+++ b/custom-images/constants.py
@@ -52,7 +52,8 @@ daisy_wf = """\
                 {{
                     "Name": "{image_name}-install",
                     "SourceImage": "{dataproc_base_image}",
-                    "Type": "pd-ssd"
+                    "Type": "pd-ssd",
+                    "SizeGb": "{disk_size}"
                 }}
             ]
         }},

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -350,6 +350,15 @@ def run():
       that builds the custom image. If not specified, Daisy would use the
       default service account under the GCE project. The scope of this service
       account is defaulted to /auth/cloud-platform.""")
+  parser.add_argument(
+      "--disk-size",
+      type=int,
+      required=False,
+      default=10,
+      help=
+      """(Optional) The size in GB of the disk attached to the VM instance
+      that builds the custom image. If not specified, the default value of
+      10 GB will be used.""")
 
   args = parser.parse_args()
 
@@ -381,7 +390,8 @@ def run():
       machine_type=args.machine_type,
       network=args.network,
       subnetwork=args.subnetwork,
-      service_account=args.service_account)
+      service_account=args.service_account,
+      disk_size=args.disk_size)
 
   _LOG.info("Successfully created Daisy workflow...")
 


### PR DESCRIPTION
When building custom images, a disk is generated and attached to the VM used to perform the build.

As more components are installed, the space on the attached disk may run out: This patch addresses such problem by allowing users to specify a variable disk size as an extra parameter for the script.