### PR TITLE
[Custom images] Enable build to happen on instance in shared VPC

### DIFF
--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -326,9 +326,10 @@ def run():
       "--network",
       type=str,
       required=False,
-      default="global/networks/default",
+      default="",
       help="""(Optional) Network interface used to launch the VM instance that
-      builds the custom image. Default network is 'global/networks/default'.
+      builds the custom image. Default network is 'global/networks/default'
+      when no network and subnetwork arguments are provided.
       If the default network does not exist in your project, please specify
       a valid network interface.""")
   parser.add_argument(
@@ -338,7 +339,8 @@ def run():
       default="",
       help="""(Optional) The subnetwork that is used to launch the VM instance
       that builds the custom image. A full subnetwork URL is required.
-      Default subnetwork is None.""")
+      Default subnetwork is None. For shared VPC only provide this parameter and
+      do not use the --network switch.""")
   parser.add_argument(
       "--service-account",
       type=str,
@@ -375,6 +377,13 @@ def run():
     oauth = "\n    \"OAuthPath\": \"{}\",".format(
         os.path.abspath(args.oauth))
 
+  network = args.network
+  # When the user wants to create a VM in a shared VPC,
+  # only the subnetwork argument has to be provided whereas
+  # the network one has to be left empty.
+  if not args.network and not args.subnetwork:
+    network = 'global/networks/default'
+
   # create daisy workflow
   _LOG.info("Created Daisy workflow...")
   workflow = constants.daisy_wf.format(
@@ -387,7 +396,7 @@ def run():
       gcs_bucket=args.gcs_bucket,
       dataproc_base_image=dataproc_base_image,
       machine_type=args.machine_type,
-      network=args.network,
+      network=network,
       subnetwork=args.subnetwork,
       service_account=args.service_account,
       disk_size=args.disk_size)

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -340,7 +340,7 @@ def run():
       help="""(Optional) The subnetwork that is used to launch the VM instance
       that builds the custom image. A full subnetwork URL is required.
       Default subnetwork is None. For shared VPC only provide this parameter and
-      do not use the --network switch.""")
+      do not use the --network argument.""")
   parser.add_argument(
       "--service-account",
       type=str,


### PR DESCRIPTION
The current code enforces the use of the default project network when generating the VM for the build.

This is not suitable when the instance VM for the build needs to be placed in a shared VPC, where only the subnetwork argument is required and no network argument should be used.

This patch allows the support for this feature by preventing the default network to be set when only a subnetwork argument is provided.

**Important note**: The current RELEASE binary version of Daisy does not support this feature yet (as it will enforce the use of the default network when no network attribute is passed to create a VM instance. Please check out for reference: https://github.com/GoogleCloudPlatform/compute-image-tools/issues/479). So for this feature to work, users must use Daisy binaries built from the latest commit to the master branch. In such case the feature works smoothly.