### PR TITLE
FIX: Fix generate_custom_images.py

### DIFF
--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -302,7 +302,8 @@ def run():
       "--family",
       type=str,
       required=False,
-      help="""(Optional) The family of the image.""")
+      help="""(Optional) The family of the image.""",
+      default="")
   parser.add_argument(
       "--project-id",
       type=str,
@@ -370,7 +371,7 @@ def run():
       For example:
       '--extra-sources "{\\"notes.txt\\": \\"/path/to/notes.txt\\"}"'
       """)
-parser.add_argument(
+  parser.add_argument(
       "--disk-size",
       type=int,
       required=False,


### PR DESCRIPTION
I needed to make these two changes to get this script to work on my machine:
1. indentation issue
2. Give a default to 'family' to be `''` and not `None`