### PR TITLE
Allow nested/layered custom image

### DIFF
--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -40,6 +40,11 @@ python generate_custom_image.py \
     notes](https://cloud.google.com/dataproc/docs/release-notes). To understand
     Dataproc versioning, please refer to
     [documentation](https://cloud.google.com/dataproc/docs/concepts/versioning/overview).
+    **This argument is mutually exclusive with --base-image-uri**.
+*   **--base-image-uri**: The full image URI for the base Dataproc image. The
+    customiziation script will be executed on top of this image instead of
+    an out-of-the-box Dataproc image. This image must be a valid Dataproc
+    image. **This argument is mutually exclusive with --dataproc-version.**
 *   **--customization-script**: The script used to install custom packages on
     the image.
 *   **--daisy-path**: The path to Daisy binary.

--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -86,6 +86,11 @@ python generate_custom_image.py \
     (sources in daisy)[https://googlecloudplatform.github.io/compute-image-tools/daisy-workflow-config-spec.html#sources] 
 *   **--disk-size**: The size in GB of the disk attached to the VM instance
     used to build custom image. The default is `15` GB.
+*   **--base-image-uri**: The partial image URI for the base Dataproc image. The
+    customization script will be executed on top of this image instead of an
+    out-of-the-box Dataproc image. This image must be a valid Dataproc image.
+    The format of the partial image URI is the following:
+    "projects/<project_id>/global/images/<image_name>".
 
 ### Example
 

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -47,8 +47,8 @@ import constants
 # Old style images: 1.2.3
 # New style images: 1.2.3-deb8
 _VERSION_REGEX = re.compile(r"^\d+\.\d+\.\d+(-.{4})?$")
-_IMAGE_URI = "projects/cloud-dataproc/global/images/{}"
-_PARTIAL_IMAGE_URI = re.compile(r"^projects\/.+\/global\/images\/.+$")
+_IMAGE_URI = "projects/{}/global/images/{}"
+_FULL_IMAGE_URI = re.compile(r"https:\/\/www\.googleapis\.com\/compute\/([^\/]+)\/projects\/([^\/]+)\/global\/images\/([^\/]+)$")
 logging.basicConfig()
 _LOG = logging.getLogger(__name__)
 _LOG.setLevel(logging.INFO)
@@ -56,13 +56,13 @@ _LOG.setLevel(logging.INFO)
 def _version_regex_type(s):
   """Check if version string matches regex."""
   if not _VERSION_REGEX.match(s):
-    raise argparse.ArgumentTypeError
+    raise argparse.ArgumentTypeError("Invalid version: {}.".format(s))
   return s
 
-def _partial_image_uri_regex_type(s):
+def _full_image_uri_regex_type(s):
   """Check if the partial image uri string matches regex."""
-  if not _PARTIAL_IMAGE_URI.match(s):
-    raise argparse.ArgumentTypeError
+  if not _FULL_IMAGE_URI.match(s):
+    raise argparse.ArgumentTypeError("Invalid image URI: {}.".format(s))
   return s
 
 def get_project_id():
@@ -79,6 +79,41 @@ def get_project_id():
     stdout = temp_file.read()
     return stdout.decode('utf-8').strip()
 
+def _get_image_name_and_project(uri):
+  """Get Dataproc image name and project."""
+  m = _FULL_IMAGE_URI.match(uri)
+  return m.group(2), m.group(3) # project, image_name
+
+def get_dataproc_image_version(uri):
+  """Get Dataproc image version from image URI."""
+  project, image_name = _get_image_name_and_project(uri)
+  command = ["gcloud", "compute", "images", "describe",
+             image_name, "--project", project,
+             "--format=value(labels.goog-dataproc-version)"]
+
+  # get stdout from compute images list --filters
+  with tempfile.NamedTemporaryFile() as temp_file:
+    pipe = subprocess.Popen(command, stdout=temp_file)
+    pipe.wait()
+    if pipe.returncode != 0:
+      raise RuntimeError(
+          "Cannot find dataproc base image, please check and verify "
+          "the base image URI.")
+
+    temp_file.seek(0)  # go to start of the stdout
+    stdout = temp_file.read()
+    # parse the first ready image with the dataproc version attached in labels
+    if stdout:
+      parsed_line = stdout.decode('utf-8').strip()  # should be just one value
+      return parsed_line
+
+  raise RuntimeError("Cannot find dataproc base image: %s", uri)
+
+
+def get_partial_image_uri(uri):
+  """Get the partial image URI from the full image URI."""
+  project, image_name = _get_image_name_and_project(uri)
+  return _IMAGE_URI.format(project, image_name)
 
 def get_dataproc_base_image(version):
   """Get Dataproc base image name from version."""
@@ -105,7 +140,7 @@ def get_dataproc_base_image(version):
     if stdout:
       parsed_line = stdout.decode('utf-8').strip().split(",")  # should only be one image
       if len(parsed_line) == 2 and parsed_line[0] and parsed_line[1] == "READY":
-        return _IMAGE_URI.format(parsed_line[0])
+        return _IMAGE_URI.format('cloud-dataproc', parsed_line[0])
 
   raise RuntimeError("Cannot find dataproc base image with "
                      "dataproc-version=%s.", version)
@@ -136,12 +171,19 @@ def run_daisy(daisy_path, workflow):
       pass
 
 
-def set_custom_image_label(image_name, version, project_id):
+def set_custom_image_label(image_name, version, project_id, parsed=False):
   """Set Dataproc version label in the newly built custom image."""
-  # version regex already checked in arg parser
-  parsed_version = version.split(".")
-  filter_arg = "--labels=goog-dataproc-version={}-{}-{}".format(
-      parsed_version[0], parsed_version[1], parsed_version[2])
+  # parse the verions if version is still in the format of
+  # <major>.<minor>.<subminor>.
+  if not parsed:
+    # version regex already checked in arg parser
+    parsed_version = version.split(".")
+    filter_arg = "--labels=goog-dataproc-version={}-{}-{}".format(
+        parsed_version[0], parsed_version[1], parsed_version[2])
+  else:
+    # in this case, the version is already in the format of
+    # <major>-<minor>-<subminor>
+    filter_arg = "--labels=goog-dataproc-version={}".format(version)
   command = ["gcloud", "compute", "images", "add-labels",
              image_name, "--project", project_id, filter_arg]
 
@@ -283,11 +325,19 @@ def run():
       type=str,
       required=True,
       help="""The image name for the Dataproc custom image.""")
-  required_args.add_argument(
+  image_args = required_args.add_mutually_exclusive_group()
+  image_args.add_argument(
       "--dataproc-version",
       type=_version_regex_type,
-      required=True,
       help=constants.version_help_text)
+  image_args.add_argument(
+      "--base-image-uri",
+      type=_full_image_uri_regex_type,
+      help="""The full image URI for the base Dataproc image. The
+      customiziation script will be executed on top of this image instead of
+      an out-of-the-box Dataproc image. This image must be a valid Dataproc
+      image.
+      """)
   required_args.add_argument(
       "--customization-script",
       type=str,
@@ -388,16 +438,6 @@ def run():
       """(Optional) The size in GB of the disk attached to the VM instance
       that builds the custom image. If not specified, the default value of
       15 GB will be used.""")
-  parser.add_argument(
-      "--base-image-uri",
-      type=_partial_image_uri_regex_type,
-      help=
-      """(Optional) The partial image URI for the base Dataproc image. The
-      customiziation script will be executed on top of this image instead of
-      an out-of-the-box Dataproc image. This image must be a valid Dataproc
-      image. The format of the partial image URI is the following:
-      "projects/<project_id>/global/images/<image_name>"
-      """)
 
 
   args = parser.parse_args()
@@ -405,12 +445,15 @@ def run():
   # get dataproc base image from dataproc version
   project_id = get_project_id() if not args.project_id else args.project_id
   _LOG.info("Getting Dataproc base image name...")
+  parsed_image_version = False
   if args.base_image_uri:
-    dataproc_base_image = args.base_image_uri
+    dataproc_base_image = get_partial_image_uri(args.base_image_uri)
+    dataproc_version = get_dataproc_image_version(args.base_image_uri)
+    parsed_image_version = True
   else:
     dataproc_base_image = get_dataproc_base_image(args.dataproc_version)
+    dataproc_version = args.dataproc_version
   _LOG.info("Returned Dataproc base image: %s", dataproc_base_image)
-
   run_script_path = os.path.join(
       os.path.dirname(os.path.realpath(__file__)), "run.sh")
 
@@ -460,8 +503,8 @@ def run():
 
   # set custom image label
   _LOG.info("Setting label on custom image...")
-  set_custom_image_label(args.image_name, args.dataproc_version,
-                         project_id)
+  set_custom_image_label(args.image_name, dataproc_version,
+                         project_id, parsed_image_version)
   _LOG.info("Successfully set label on custom image...")
 
   # perform test on the newly built image


### PR DESCRIPTION
allow user to specify an image URI of a base Dataproc image to be built
on top of. This image URI can be an official Dataproc image or a valid
custom image.