### PR TITLE
Increase and allow to modify timer before vm shutdown

### DIFF
--- a/custom-images/constants.py
+++ b/custom-images/constants.py
@@ -64,7 +64,8 @@ daisy_wf = """\
                     "MachineType": "{machine_type}",
                     "NetworkInterfaces": [{{"network": "{network}", "subnetwork": "{subnetwork}"}}],
                     "ServiceAccounts": [{{"Email": "{service_account}", "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]}}],
-                    "StartupScript": "run.sh"
+                    "StartupScript": "run.sh",
+                    "Metadata": {{"shutdown-timer-in-sec" : "{shutdown_timer_in_sec}"}}
                 }}
             ]
         }},

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -438,6 +438,16 @@ def run():
       """(Optional) The size in GB of the disk attached to the VM instance
       that builds the custom image. If not specified, the default value of
       15 GB will be used.""")
+  parser.add_argument(
+      "--shutdown-instance-timer-sec",
+      type=int,
+      required=False,
+      default=300,
+      help=
+      """(Optional) The time to wait in seconds before shutting down the VM
+      instance. This value may need to be increased if your init script
+      generates a lot of output on stdout. If not specified, the default value
+      of 300 seconds will be used.""")
 
 
   args = parser.parse_args()
@@ -492,7 +502,8 @@ def run():
       network=network,
       subnetwork=args.subnetwork,
       service_account=args.service_account,
-      disk_size=args.disk_size)
+      disk_size=args.disk_size,
+      shutdown_timer_in_sec=args.shutdown_instance_timer_sec)
 
   _LOG.info("Successfully created Daisy workflow...")
 

--- a/custom-images/run.sh
+++ b/custom-images/run.sh
@@ -14,6 +14,8 @@
 
 # get daisy-sources-path
 DAISY_SOURCES_PATH=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/daisy-sources-path" -H "Metadata-Flavor: Google")
+# get time to wait for stdout to flush
+SHUTDOWN_TIMER_IN_SEC=$(curl "http://metadata.google.internal/computeMetadata/v1/instance/attributes/shutdown-timer-in-sec" -H "Metadata-Flavor: Google")
 
 # copy down all sources (along with init_actions.sh script)
 gsutil -m cp -r "${DAISY_SOURCES_PATH}/*" ./
@@ -31,6 +33,6 @@ else
   echo "BuildSucceeded: Dataproc Initialization Actions Succeeded."
 fi
 
-sleep 20 # wait for stdout to flush
+sleep ${SHUTDOWN_TIMER_IN_SEC} # wait for stdout to flush
 
 shutdown -h now


### PR DESCRIPTION
Once the custom initialization script is executed, the VM instance will wait 20 seconds before shutting down.

If the custom initialization produces a considerable amount of text on stdout, the instance may not have the time to flush all of its output and Daisy may miss to capture the signal on serial port marking success/failure.

We can solve this by simply increasing the timeout before shutdown of the VM instance (now 300 seconds).

To make it easier to modify this value in the future, I also added an extra parameter to the generate_custom_image.py script.