### PR TITLE
Add additional metadata to the VM building the image

### DIFF
--- a/custom-images/README.md
+++ b/custom-images/README.md
@@ -89,6 +89,8 @@ python generate_custom_image.py \
     customization script. This argument is evaluated to a json dictionary.
     Read more about
     (sources in daisy)[https://googlecloudplatform.github.io/compute-image-tools/daisy-workflow-config-spec.html#sources] 
+*   **--metadata**: A list of comma-separated key=value pairs that will be
+    set as metadata in the VM instance that builds the custom Dataproc image.
 *   **--disk-size**: The size in GB of the disk attached to the VM instance
     used to build custom image. The default is `15` GB.
 *   **--base-image-uri**: The partial image URI for the base Dataproc image. The

--- a/custom-images/constants.py
+++ b/custom-images/constants.py
@@ -65,7 +65,7 @@ daisy_wf = """\
                     "NetworkInterfaces": [{{"network": "{network}", "subnetwork": "{subnetwork}"}}],
                     "ServiceAccounts": [{{"Email": "{service_account}", "Scopes": ["https://www.googleapis.com/auth/cloud-platform"]}}],
                     "StartupScript": "run.sh",
-                    "Metadata": {{"shutdown-timer-in-sec" : "{shutdown_timer_in_sec}"}}
+                    "Metadata": {{"shutdown-timer-in-sec" : "{shutdown_timer_in_sec}"{metadata}}}
                 }}
             ]
         }},

--- a/custom-images/generate_custom_image.py
+++ b/custom-images/generate_custom_image.py
@@ -68,7 +68,7 @@ def _full_image_uri_regex_type(s):
 
 def _metadata_regex_type(s):
   """Check if the metadata string matches regex."""
-  if not _METADATA_REGEX.match(s):
+  if s and not _METADATA_REGEX.match(s):
     raise argparse.ArgumentTypeError("Invalid metadata string: {}.".format(s))
   return s
 


### PR DESCRIPTION
Once you start to have multiple and complex script for custom images it becomes very handy to be able to set additional metadata in the VM that will run the custom init script.

As an example, if you have a side repository with some library code that you want to reuse in the custom init script, you can use metadata to decide in the script which repository branch to clone (test vs production).

For the reviewers: I could not find a good resource explaining which rules are supposed to be used for validating metadata names and values so for now I have a very naive regular expression. I would appreciate if you could guide on how to improve that.