### PR TITLE
Rename plugins.sbt to assembly.sbt

### DIFF
--- a/spark-translate/.gitignore
+++ b/spark-translate/.gitignore
@@ -3,4 +3,4 @@ maven/dependency-reduced-pom.xml
 
 sbt/target/**
 sbt/project/**
-!sbt/project/plugins.sbt
+!sbt/project/assembly.sbt

--- a/spark-translate/sbt/project/assembly.sbt
+++ b/spark-translate/sbt/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")

--- a/spark-translate/sbt/project/plugins.sbt
+++ b/spark-translate/sbt/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")


### PR DESCRIPTION
While the filename doesn't really matter, it is more common to name this file `assembly.sbt`.