### PR TITLE
Fix(gcloud): Correct service account email format and improve creation

### DIFF
--- a/gcloud/lib/env.sh
+++ b/gcloud/lib/env.sh
@@ -57,7 +57,16 @@ export DATAPROC_IMAGE_VERSION="${IMAGE_VERSION}"
 #export INIT_ACTIONS_ROOT="gs://goog-dataproc-initialization-actions-${REGION}"
 export AUTOSCALING_POLICY_NAME=aspolicy-${CLUSTER_NAME}
 export SA_NAME=sa-${CLUSTER_NAME}
-export GSA=${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
+
+if [[ "${PROJECT_ID}" == *":"* ]]; then
+  # Domain-scoped project
+  DOMAIN=$(echo "${PROJECT_ID}" | cut -d':' -f1)
+  PROJECT_NAME=$(echo "${PROJECT_ID}" | cut -d':' -f2)
+  export GSA="${SA_NAME}@${PROJECT_NAME}.${DOMAIN}.iam.gserviceaccount.com"
+else
+  # Regular project
+  export GSA="${SA_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
+fi
 
 export INIT_ACTIONS_ROOT="gs://${BUCKET}/dataproc-initialization-actions"
 export YARN_DOCKER_IMAGE="gcr.io/${PROJECT_ID}/${USER}/cudatest-ubuntu18:latest"


### PR DESCRIPTION
This commit addresses issues in the create-dpgce script related to service account handling, particularly for domain-scoped projects.

- lib/env.sh:
  - Correctly formats the service account email (GSA) for domain-scoped projects (e.g., c9h.org:project-id) by including the domain in the email address (e.g., sa-name@project-id.c9h.org.iam.gserviceaccount.com).

- lib/shared-functions.sh:
  - Replaced `gcloud iam service-accounts describe` with `list --filter` for a more reliable existence check, as describe was failing to find existing service accounts.
  - Added a retry loop for `gcloud projects add-iam-policy-binding` to handle potential IAM propagation delays after service account creation.
  - Ensured the script exits if role bindings fail after multiple retries.
  - Cleaned up role binding logic into a loop.

These changes ensure the script can reliably create and configure the necessary service account and its IAM roles, unblocking cluster creation.